### PR TITLE
refactor(rendering): Implement layered canvas for performance

### DIFF
--- a/Planning.md
+++ b/Planning.md
@@ -152,7 +152,7 @@ To decouple the simulation from the UI and improve performance, a centralized ev
 
 ## 6. Component Architecture (`src/components/`)
 -   **`App.tsx`**: Root component. Manages UI state (sidebar visibility), orchestrates the `useSimulation` hook, and handles the save/load logic on the main thread.
--   **`SimulationView.tsx`**: A pure presentation component that renders the `grid` state onto an HTML5 canvas. It also handles click events to report selected flowers.
+-   **`SimulationView.tsx`**: The host component for the rendering engine. It creates and manages two stacked `<canvas>` elements (one for static background, one for dynamic foreground) and passes them to the `RenderingEngine`. It also captures user click events on the top canvas and forwards them to the application state.
 -   **`Controls.tsx`**: The UI for all `SimulationParams`, allowing users to configure and reset the simulation.
 -   **`FlowerDetailsPanel.tsx`**: Displays detailed data for a selected flower, including stats, genome, and a button to launch the 3D viewer.
 -   **`Flower3DViewer.tsx`**: Renders a flower's 3D model using `@react-three/fiber` inside a modal.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ export default function App(): React.ReactNode {
   }, [params]);
 
 
-  const { grid, isRunning, setIsRunning, workerRef, resetWithNewParams, isWorkerInitialized } = useSimulation({ setIsLoading });
+  const { actors, isRunning, setIsRunning, workerRef, resetWithNewParams, isWorkerInitialized } = useSimulation({ setIsLoading });
 
   // Initialize the main-thread event service
   useEffect(() => {
@@ -129,19 +129,10 @@ export default function App(): React.ReactNode {
 
 
   const selectedFlower = useMemo(() => {
-    if (!selectedFlowerId || !grid) return null;
-    for (const row of grid) {
-        for (const cell of row) {
-            const flower = cell.find(
-                (entity): entity is Flower => entity.type === 'flower' && entity.id === selectedFlowerId
-            );
-            if (flower) {
-                return flower;
-            }
-        }
-    }
-    return null;
-  }, [selectedFlowerId, grid]);
+    if (!selectedFlowerId) return null;
+    const actor = actors.get(selectedFlowerId);
+    return actor?.type === 'flower' ? actor : null;
+  }, [selectedFlowerId, actors]);
 
   const handleParamsChange = (newParams: SimulationParams) => {
     setIsRunning(false); // Stop the simulation on reset
@@ -373,7 +364,7 @@ export default function App(): React.ReactNode {
         <div ref={simulationViewRef} className="grow flex flex-col h-full">
           <SimulationView 
             params={params}
-            grid={grid}
+            actors={actors}
             onSelectFlower={handleSelectFlower}
             selectedFlowerId={selectedFlowerId}
           />

--- a/src/components/SimulationView.tsx
+++ b/src/components/SimulationView.tsx
@@ -1,124 +1,52 @@
-import React, { useRef, useEffect, useCallback } from 'react';
-import type { Grid, Flower, SimulationParams, CellContent, Insect } from '../types';
+import React, { useRef, useEffect, useCallback, useState } from 'react';
+import type { Flower, SimulationParams, CellContent } from '../types';
+import { RenderingEngine } from '../lib/renderingEngine';
 
 const CELL_SIZE_PX = 64;
-const GRID_COLOR = 'hsla(120, 100%, 50%, 0.2)';
-const SELECTED_CELL_COLOR = 'hsla(120, 100%, 50%, 0.4)';
 
-// Cache for loaded flower images to prevent flickering and re-loading
-const imageCache = new Map<string, HTMLImageElement>();
-
-const drawCell = (
-    ctx: CanvasRenderingContext2D,
-    cell: CellContent[],
-    x: number,
-    y: number,
-    rerender: () => void
-) => {
-    if (!cell || cell.length === 0) return;
-
-    const px = x * CELL_SIZE_PX;
-    const py = y * CELL_SIZE_PX;
-    
-    const flower = cell.find(c => c.type === 'flower') as Flower | undefined;
-    const otherEntities = cell.filter(c => c.type !== 'flower');
-
-    if (flower) {
-        // Add a guard to ensure imageData exists and is a non-empty string.
-        // This prevents errors if the WASM module fails to generate an SVG.
-        if (!flower.imageData || typeof flower.imageData !== 'string') {
-            return;
-        }
-
-        const dataUrl = `${flower.imageData}`;
-        let img = imageCache.get(dataUrl);
-
-        if (img) {
-            if (img.complete) {
-                ctx.drawImage(img, px, py, CELL_SIZE_PX, CELL_SIZE_PX);
-            }
-        } else {
-            img = new Image();
-            img.onload = () => {
-                rerender(); // Trigger a rerender to draw the newly loaded image
-            };
-            img.src = dataUrl;
-            imageCache.set(dataUrl, img);
-        }
-    }
-    
-    if (otherEntities.length > 0) {
-        ctx.font = `${CELL_SIZE_PX * 0.6}px sans-serif`;
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        
-        for (const entity of otherEntities) {
-            const emoji =
-                entity.type === 'bird' ? '🐦' :
-                entity.type === 'eagle' ? '🦅' :
-                entity.type === 'insect' ? (entity as Insect).emoji :
-                entity.type === 'nutrient' ? '💩' :
-                entity.type === 'egg' ? '🥚' :
-                entity.type === 'herbicidePlane' ? '✈️' :
-                entity.type === 'herbicideSmoke' ? '💨' : '';
-            
-            if (emoji) {
-                ctx.save();
-                ctx.globalAlpha = 0.8;
-                ctx.fillText(emoji, px + CELL_SIZE_PX / 2, py + CELL_SIZE_PX / 2);
-                ctx.restore();
-            }
-        }
-    }
-};
-
-interface SimulationCanvasProps {
-    grid: Grid;
+interface SimulationViewProps {
     params: SimulationParams;
     onSelectFlower: (flower: Flower | null) => void;
     selectedFlowerId: string | null;
+    actors: Map<string, CellContent>;
 }
 
-const SimulationCanvas: React.FC<SimulationCanvasProps> = ({ grid, params, onSelectFlower, selectedFlowerId }) => {
-    const canvasRef = useRef<HTMLCanvasElement | null>(null);
-    const [, setForceRender] = React.useState(0);
-    const rerender = useCallback(() => setForceRender(tick => tick + 1), []);
+export const SimulationView: React.FC<SimulationViewProps> = ({ params, onSelectFlower, selectedFlowerId, actors }) => {
+    const bgCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const fgCanvasRef = useRef<HTMLCanvasElement | null>(null);
+    const engineRef = useRef<RenderingEngine | null>(null);
+    const [isEngineReady, setIsEngineReady] = useState(false);
 
+    // Initialize rendering engine
     useEffect(() => {
-        const canvas = canvasRef.current;
-        if (!canvas) return;
+        const bgCanvas = bgCanvasRef.current;
+        const fgCanvas = fgCanvasRef.current;
 
-        const ctx = canvas.getContext('2d');
-        if (!ctx) return;
-
-        // Clear canvas
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-        // Draw grid lines and entities
-        for (let y = 0; y < params.gridHeight; y++) {
-            for (let x = 0; x < params.gridWidth; x++) {
-                const cell = grid[y]?.[x];
-
-                // Draw cell background/border
-                ctx.strokeStyle = GRID_COLOR;
-                ctx.strokeRect(x * CELL_SIZE_PX, y * CELL_SIZE_PX, CELL_SIZE_PX, CELL_SIZE_PX);
-                
-                // Draw entities in cell
-                if (cell) {
-                    drawCell(ctx, cell, x, y, rerender);
-                }
-
-                // Highlight selected flower
-                if (cell?.some(c => c.type === 'flower' && c.id === selectedFlowerId)) {
-                    ctx.fillStyle = SELECTED_CELL_COLOR;
-                    ctx.fillRect(x * CELL_SIZE_PX, y * CELL_SIZE_PX, CELL_SIZE_PX, CELL_SIZE_PX);
-                }
-            }
+        if (bgCanvas && fgCanvas && !engineRef.current) {
+            engineRef.current = new RenderingEngine(bgCanvas, fgCanvas, params);
+            engineRef.current.drawGrid();
+            setIsEngineReady(true);
         }
-    }, [grid, params, selectedFlowerId, rerender]);
+    }, [params]);
+    
+    // Update engine with new params
+    useEffect(() => {
+        if (isEngineReady && engineRef.current) {
+            engineRef.current.updateParams(params);
+        }
+    }, [params, isEngineReady]);
 
-    const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
-        const canvas = canvasRef.current;
+
+    // Main draw loop
+    useEffect(() => {
+        if (isEngineReady && engineRef.current) {
+            engineRef.current.draw(actors, selectedFlowerId);
+        }
+    }, [actors, selectedFlowerId, isEngineReady]);
+
+
+    const handleClick = useCallback((event: React.MouseEvent<HTMLCanvasElement>) => {
+        const canvas = fgCanvasRef.current;
         if (!canvas) return;
 
         const rect = canvas.getBoundingClientRect();
@@ -128,43 +56,39 @@ const SimulationCanvas: React.FC<SimulationCanvasProps> = ({ grid, params, onSel
         const gridX = Math.floor(x / CELL_SIZE_PX);
         const gridY = Math.floor(y / CELL_SIZE_PX);
 
-        const cell = grid[gridY]?.[gridX];
-        const flowerInCell = cell?.find(c => c.type === 'flower') as Flower | undefined;
-        onSelectFlower(flowerInCell || null);
-    };
+        let clickedFlower: Flower | null = null;
+        // Find if a flower exists at the clicked coordinates from the actors map
+        for (const actor of actors.values()) {
+            if (actor.type === 'flower' && actor.x === gridX && actor.y === gridY) {
+                clickedFlower = actor;
+                break;
+            }
+        }
+        onSelectFlower(clickedFlower);
+    }, [actors, onSelectFlower]);
 
-    return (
-        <canvas
-            ref={canvasRef}
-            width={params.gridWidth * CELL_SIZE_PX}
-            height={params.gridHeight * CELL_SIZE_PX}
-            onClick={handleClick}
-            className="bg-surface/50 rounded-lg shadow-inner cursor-pointer"
-            role="grid"
-            aria-label="EvoGarden simulation grid"
-        />
-    );
-};
+    const canvasWidth = params.gridWidth * CELL_SIZE_PX;
+    const canvasHeight = params.gridHeight * CELL_SIZE_PX;
 
-
-interface SimulationViewProps {
-    params: SimulationParams;
-    onSelectFlower: (flower: Flower | null) => void;
-    selectedFlowerId: string | null;
-    grid: Grid;
-}
-
-export const SimulationView: React.FC<SimulationViewProps> = ({ params, onSelectFlower, selectedFlowerId, grid }) => {
     return (
         <div className="grow bg-surface rounded-lg overflow-auto flex items-center justify-center p-4">
-            {grid.length > 0 && ( // Ensure grid is initialized before rendering canvas
-                <SimulationCanvas
-                    grid={grid}
-                    params={params}
-                    onSelectFlower={onSelectFlower}
-                    selectedFlowerId={selectedFlowerId}
+            <div
+                style={{ width: canvasWidth, height: canvasHeight, position: 'relative' }}
+                className="bg-surface/50 rounded-lg shadow-inner"
+            >
+                <canvas
+                    ref={bgCanvasRef}
+                    className="absolute top-0 left-0"
+                    aria-hidden="true" // Decorative background
                 />
-            )}
+                <canvas
+                    ref={fgCanvasRef}
+                    onClick={handleClick}
+                    className="absolute top-0 left-0 cursor-pointer"
+                    role="grid"
+                    aria-label="EvoGarden simulation grid"
+                />
+            </div>
         </div>
     );
 };

--- a/src/lib/renderingEngine.ts
+++ b/src/lib/renderingEngine.ts
@@ -1,0 +1,193 @@
+import type { CellContent, Flower, Insect, SimulationParams } from '../types';
+
+const CELL_SIZE_PX = 64;
+const GRID_COLOR = 'hsla(120, 100%, 50%, 0.2)';
+const SELECTED_CELL_COLOR = 'hsla(120, 100%, 50%, 0.4)';
+const SAPLING_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><path d="M32 56V24M32 24C32 12 40 12 40 12M32 24C32 12 24 12 24 12" stroke="lightgreen" stroke-width="4" fill="none" stroke-linecap="round"/></svg>`;
+const SAPLING_IMAGE_DATA_URL = `data:image/svg+xml;base64,${btoa(SAPLING_SVG)}`;
+
+/**
+ * Helper function to efficiently check if the members of two sets are different.
+ */
+function haveSetsChanged<T>(setA: Set<T>, setB: Set<T>): boolean {
+    if (setA.size !== setB.size) return true;
+    for (const item of setA) {
+        if (!setB.has(item)) return true;
+    }
+    return false;
+}
+
+export class RenderingEngine {
+    private bgCanvas: HTMLCanvasElement;
+    private fgCanvas: HTMLCanvasElement;
+    private bgCtx: CanvasRenderingContext2D;
+    private fgCtx: CanvasRenderingContext2D;
+    private params: SimulationParams;
+    private imageCache = new Map<string, HTMLImageElement>();
+    private saplingImage: HTMLImageElement;
+    
+    // State for change detection
+    private lastStaticActorIds = new Set<string>();
+    private lastSelectedId: string | null = null;
+    
+    constructor(bgCanvas: HTMLCanvasElement, fgCanvas: HTMLCanvasElement, params: SimulationParams) {
+        this.bgCanvas = bgCanvas;
+        this.fgCanvas = fgCanvas;
+        this.params = params;
+
+        const bgCtx = bgCanvas.getContext('2d');
+        const fgCtx = fgCanvas.getContext('2d');
+        if (!bgCtx || !fgCtx) {
+            throw new Error("Could not get canvas contexts");
+        }
+        this.bgCtx = bgCtx;
+        this.fgCtx = fgCtx;
+
+        this.saplingImage = new Image();
+        this.saplingImage.src = SAPLING_IMAGE_DATA_URL;
+
+        this.updateCanvasSize();
+    }
+
+    public updateParams(newParams: SimulationParams) {
+        this.params = newParams;
+        this.updateCanvasSize();
+        // Force a full redraw of static elements on the next frame
+        this.lastStaticActorIds.clear(); 
+        this.lastSelectedId = null;
+    }
+
+    private updateCanvasSize() {
+        const width = this.params.gridWidth * CELL_SIZE_PX;
+        const height = this.params.gridHeight * CELL_SIZE_PX;
+        this.bgCanvas.width = width;
+        this.bgCanvas.height = height;
+        this.fgCanvas.width = width;
+        this.fgCanvas.height = height;
+    }
+
+    public drawGrid() {
+        this.bgCtx.clearRect(0, 0, this.bgCanvas.width, this.bgCanvas.height);
+        this.bgCtx.strokeStyle = GRID_COLOR;
+        for (let y = 0; y < this.params.gridHeight; y++) {
+            for (let x = 0; x < this.params.gridWidth; x++) {
+                this.bgCtx.strokeRect(x * CELL_SIZE_PX, y * CELL_SIZE_PX, CELL_SIZE_PX, CELL_SIZE_PX);
+            }
+        }
+    }
+
+    private drawEmoji(ctx: CanvasRenderingContext2D, actor: CellContent) {
+        const emoji =
+            actor.type === 'bird' ? '🐦' :
+            actor.type === 'eagle' ? '🦅' :
+            actor.type === 'insect' ? (actor as Insect).emoji :
+            actor.type === 'nutrient' ? '💩' :
+            actor.type === 'egg' ? '🥚' :
+            actor.type === 'herbicidePlane' ? '✈️' :
+            actor.type === 'herbicideSmoke' ? '💨' : '';
+        
+        if (emoji) {
+            ctx.save();
+            ctx.globalAlpha = 0.9;
+            ctx.font = `${CELL_SIZE_PX * 0.6}px sans-serif`;
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(emoji, actor.x * CELL_SIZE_PX + CELL_SIZE_PX / 2, actor.y * CELL_SIZE_PX + CELL_SIZE_PX / 2);
+            ctx.restore();
+        }
+    }
+
+    private drawFlower(flower: Flower) {
+        if (!flower.imageData) return;
+
+        const dataUrl = `${flower.imageData}`;
+        let img = this.imageCache.get(dataUrl);
+
+        if (img?.complete) {
+            this.bgCtx.drawImage(img, flower.x * CELL_SIZE_PX, flower.y * CELL_SIZE_PX, CELL_SIZE_PX, CELL_SIZE_PX);
+        } else if (!img) {
+            img = new Image();
+            img.onload = () => {
+                // Image has loaded. Force a redraw on the next frame by invalidating the actor set.
+                // The next call to draw() will now see a change and redraw the static layer.
+                this.lastStaticActorIds.clear();
+            };
+            img.src = dataUrl;
+            this.imageCache.set(dataUrl, img);
+        }
+    }
+
+    public draw(actors: Map<string, CellContent>, selectedFlowerId: string | null) {
+        const staticActors = new Map<string, Flower>();
+        const dynamicActors: CellContent[] = [];
+
+        for (const actor of actors.values()) {
+            if (actor.type === 'flower') {
+                staticActors.set(actor.id, actor);
+            } else {
+                dynamicActors.push(actor);
+            }
+        }
+
+        // --- Change Detection ---
+        const currentStaticActorIds = new Set(staticActors.keys());
+        const staticActorsChanged = haveSetsChanged(this.lastStaticActorIds, currentStaticActorIds);
+        const selectionChanged = this.lastSelectedId !== selectedFlowerId;
+
+        // Only redraw the expensive static layer if something has actually changed.
+        if (staticActorsChanged || selectionChanged) {
+            this.drawStaticLayer(staticActors, selectedFlowerId);
+            this.lastStaticActorIds = currentStaticActorIds;
+            this.lastSelectedId = selectedFlowerId;
+        }
+
+        this.drawDynamicLayer(dynamicActors);
+    }
+
+    private _collectGarbage(currentFlowers: Map<string, Flower>) {
+        const activeImageUrls = new Set<string>();
+        for (const flower of currentFlowers.values()) {
+            if (flower.imageData) {
+                activeImageUrls.add(flower.imageData);
+            }
+        }
+        for (const cachedUrl of this.imageCache.keys()) {
+            if (!activeImageUrls.has(cachedUrl)) {
+                this.imageCache.delete(cachedUrl);
+            }
+        }
+    }
+    
+    /**
+     * Performs a full, clean redraw of the static background layer.
+     * This is an expensive operation and should only be called when necessary.
+     */
+    private drawStaticLayer(currentFlowers: Map<string, Flower>, selectedFlowerId: string | null) {
+        // 1. Clear canvas and redraw grid lines
+        this.drawGrid();
+
+        // 2. Draw all current flowers
+        for (const flower of currentFlowers.values()) {
+            this.drawFlower(flower);
+        }
+
+        // 3. Draw selection highlight on top
+        if (selectedFlowerId) {
+            const selectedFlower = currentFlowers.get(selectedFlowerId);
+            if (selectedFlower) {
+                this.bgCtx.fillStyle = SELECTED_CELL_COLOR;
+                this.bgCtx.fillRect(selectedFlower.x * CELL_SIZE_PX, selectedFlower.y * CELL_SIZE_PX, CELL_SIZE_PX, CELL_SIZE_PX);
+            }
+        }
+        
+        // 4. Clean up the image cache
+        this._collectGarbage(currentFlowers);
+    }
+
+    private drawDynamicLayer(dynamicActors: CellContent[]) {
+        this.fgCtx.clearRect(0, 0, this.fgCanvas.width, this.fgCanvas.height);
+        for (const actor of dynamicActors) {
+            this.drawEmoji(this.fgCtx, actor);
+        }
+    }
+}


### PR DESCRIPTION
This refactor addresses a major rendering bottleneck by splitting the single simulation canvas into two stacked layers:

* A static background canvas for the grid and flowers.
* A dynamic foreground canvas for mobile actors (insects, birds, etc.).

A new RenderingEngine class now manages both canvases and implements change detection. The background layer is only redrawn when a flower is added, removed, or the selection changes. The foreground layer is cleared and redrawn every tick with only the lightweight emoji-based actors.

This change significantly improves rendering performance and reduces CPU load on the main thread, leading to a much smoother user experience, especially with a large number of static actors.