### PR TITLE
feat: Add emissive material toggle to 3D flower viewer

### DIFF
--- a/Planning.md
+++ b/Planning.md
@@ -154,7 +154,7 @@ To decouple the simulation from the UI and improve performance, a centralized ev
 -   **`App.tsx`**: Root component. Manages UI state (sidebar visibility), orchestrates the `useSimulation` hook, and handles the save/load logic on the main thread.
 -   **`SimulationView.tsx`**: The host component for the rendering engine. It creates and manages two stacked `<canvas>` elements (one for static background, one for dynamic foreground) and passes them to the `RenderingEngine`. It also captures user click events on the top canvas and forwards them to the application state.
 -   **`Controls.tsx`**: The UI for all `SimulationParams`, allowing users to configure and reset the simulation.
--   **`FlowerDetailsPanel.tsx`**: Displays detailed data for a selected flower, including stats, genome, and a button to launch the 3D viewer.
+-   **`FlowerDetailsPanel.tsx`**: Displays detailed data for a selected flower, including stats, genome, and a button to launch the 3D viewer. Includes a toggle for emissive materials.
 -   **`Flower3DViewer.tsx`**: Renders a flower's 3D model using `@react-three/fiber` inside a modal.
 -   **`DataPanel.tsx`**: A slide-out panel with a tabbed interface for switching between `ChallengesPanel` and `ChartsPanel`.
 -   **`ChallengesPanel.tsx`**: Subscribes to `challengeStore` and displays challenge progress.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A dynamic garden simulation where flowers evolve under the pressure of insects a
 -   **WASM-Powered Genetics**: A high-performance WebAssembly module handles complex genetic operations like mutation, reproduction, and stat calculation.
 -   **Interactive Simulation**: Control world parameters like climate and population, pause/play the world, and reset with new initial conditions.
 -   **Inspect Individuals**: Click on any flower to view its detailed real-time stats, including health, age, genetic traits, and its raw genome, which can be copied or downloaded as a JSON file.
--   **Interactive 3D Flower Viewer**: Generate and view a 3D model of any flower from its genome in an interactive modal viewer with camera controls. The simulation automatically pauses while viewing.
+-   **Interactive 3D Flower Viewer**: Generate and view a 3D model of any flower from its genome in an interactive modal viewer with camera controls and an option for emissive materials for a glowing effect. The simulation automatically pauses while viewing.
 -   **Intuitive Interaction**: Click on an empty cell or outside the details panel to close it and seamlessly resume the simulation, providing a fluid user experience.
 
 ## 🛠️ Tech Stack

--- a/src/components/FlowerDetailsPanel.tsx
+++ b/src/components/FlowerDetailsPanel.tsx
@@ -28,6 +28,7 @@ export const FlowerDetailsPanel: React.FC<FlowerDetailsPanelProps> = ({ flower, 
     const [is3DViewerOpen, setIs3DViewerOpen] = useState(false);
     const [gltfString, setGltfString] = useState<string | null>(null);
     const [isLoading3D, setIsLoading3D] = useState(false);
+    const [useEmissive, setUseEmissive] = useState(false);
     const wasRunningRef = useRef(false);
 
     const handleCopyGenome = useCallback(() => {
@@ -58,7 +59,10 @@ export const FlowerDetailsPanel: React.FC<FlowerDetailsPanelProps> = ({ flower, 
         setIs3DViewerOpen(true);
         
         try {
-            const gltf = await flowerService.draw3DFlower(flower.genome);
+            const gltf = useEmissive
+                ? await flowerService.drawEmissive3DFlower(flower.genome, flower.sex)
+                : await flowerService.draw3DFlower(flower.genome, flower.sex);
+
             setGltfString(gltf);
         } catch (error) {
             console.error("Failed to generate 3D model:", error);
@@ -139,7 +143,17 @@ export const FlowerDetailsPanel: React.FC<FlowerDetailsPanelProps> = ({ flower, 
                     </div>
                 </div>
 
-                <div className="pt-2">
+                <div className="pt-2 space-y-2">
+                    <label className="flex items-center space-x-2 cursor-pointer p-2 bg-surface-hover/50 rounded-md hover:bg-surface-hover">
+                        <input
+                            type="checkbox"
+                            checked={useEmissive}
+                            onChange={(e) => setUseEmissive(e.target.checked)}
+                            className="h-4 w-4 rounded bg-surface border-border text-accent-green focus:ring-accent-green"
+                        />
+                        <span className="text-sm text-secondary">Use Emissive Material</span>
+                    </label>
+
                     <button
                         onClick={handleView3D}
                         disabled={isLoading3D}

--- a/src/flower-evolver-wasm.d.ts
+++ b/src/flower-evolver-wasm.d.ts
@@ -1,5 +1,9 @@
 declare module '@cristianglezm/flower-evolver-wasm' {
   export class FEParams {
+    radius: number;
+    numLayers: number;
+    P: number;
+    bias: number;
     constructor(radius: number, numLayers: number, P: number, bias: number);
   }
 
@@ -10,7 +14,11 @@ declare module '@cristianglezm/flower-evolver-wasm' {
     constructor();
     init(): Promise<void>;
     setParams(params: FEParams): void;
+    getParams(): FEParams;
     makeFlower(): Promise<{ genome: string; image: string }>;
+    makePetals(): Promise<{ genome: string; image: string }>;
+    makePetalLayer(layer: number): Promise<{ genome: string; image: string }>;
+    makeStem(): Promise<{ genome: string; image: string }>;
     reproduce(father: string, mother: string): Promise<{ genome: string; image: string }>;
     mutate(
       original: string,
@@ -29,7 +37,14 @@ declare module '@cristianglezm/flower-evolver-wasm' {
       altitude?: number,
       terrainType?: number
     ): Promise<any>;
-    draw3DFlower(genome: string, flowerId: string, format: "both" | "gltf" | "glb"): Promise<string>;
     drawFlower(genome: string): Promise<{ genome: string; image: string }>;
+    drawPetals(genome: string): Promise<{ genome: string; image: string }>;
+    drawPetalLayer(genome: string, layer: number): Promise<{ genome: string; image: string }>;
+    // Renders using current params
+    make3DFlower(genome: string, flowerId: string, sex: 'male' | 'female' | 'both'): Promise<string>;
+    makeEmissive3DFlower(genome: string, flowerId: string, sex: 'male' | 'female' | 'both'): Promise<string>;
+    // Renders using params from genome
+    draw3DFlower(genome: string, flowerId: string, sex: 'male' | 'female' | 'both'): Promise<string>;
+    drawEmissive3DFlower(genome: string, flowerId: string, sex: 'male' | 'female' | 'both'): Promise<string>;
   }
 }

--- a/src/lib/simulationEngine.test.ts
+++ b/src/lib/simulationEngine.test.ts
@@ -7,12 +7,19 @@ import type { FEService, Flower, FlowerGenomeStats, Grid, CellContent, Insect, B
 const mockFlowerService: FEService = {
     initialize: vi.fn().mockResolvedValue(undefined),
     setParams: vi.fn(),
+    getParams: vi.fn(),
     makeFlower: vi.fn(),
+    makePetals: vi.fn(),
+    makePetalLayer: vi.fn(),
+    makeStem: vi.fn(),
     reproduce: vi.fn(),
     mutate: vi.fn(),
     getFlowerStats: vi.fn(),
-    draw3DFlower: vi.fn(),
     drawFlower: vi.fn(),
+    drawPetals: vi.fn(),
+    drawPetalLayer: vi.fn(),
+    draw3DFlower: vi.fn(),
+    drawEmissive3DFlower: vi.fn(),
 };
 
 // Default mock data

--- a/src/lib/simulationInitializer.test.ts
+++ b/src/lib/simulationInitializer.test.ts
@@ -6,12 +6,19 @@ import { DEFAULT_SIM_PARAMS } from '../constants';
 const mockFlowerService: FEService = {
     initialize: vi.fn().mockResolvedValue(undefined),
     setParams: vi.fn(),
+    getParams: vi.fn(),
     makeFlower: vi.fn(),
+    makePetals: vi.fn(),
+    makePetalLayer: vi.fn(),
+    makeStem: vi.fn(),
     reproduce: vi.fn(),
     mutate: vi.fn(),
     getFlowerStats: vi.fn(),
-    draw3DFlower: vi.fn(),
     drawFlower: vi.fn(),
+    drawPetals: vi.fn(),
+    drawPetalLayer: vi.fn(),
+    draw3DFlower: vi.fn(),
+    drawEmissive3DFlower: vi.fn(),
 };
 
 const mockFlowerData = { genome: 'test-genome', image: 'test-image-data' };

--- a/src/services/flowerService.ts
+++ b/src/services/flowerService.ts
@@ -42,9 +42,29 @@ class FlowerService implements FEService {
         this.service.setParams(new FEParamsPackage(params.radius, params.numLayers, params.P, params.bias));
     }
 
+    getParams(): FEParams {
+        this.ensureInitialized();
+        return this.service.getParams();
+    }
+
     async makeFlower(): Promise<{genome: string, image: string}> {
         this.ensureInitialized();
         return await this.service.makeFlower();
+    }
+
+    async makePetals(): Promise<{ genome: string; image: string; }> {
+        this.ensureInitialized();
+        return await this.service.makePetals();
+    }
+
+    async makePetalLayer(layer: number): Promise<{ genome: string; image: string; }> {
+        this.ensureInitialized();
+        return await this.service.makePetalLayer(layer);
+    }
+
+    async makeStem(): Promise<{ genome: string; image: string; }> {
+        this.ensureInitialized();
+        return await this.service.makeStem();
     }
 
     async reproduce(father: string, mother: string): Promise<{genome: string, image: string}> {
@@ -63,16 +83,32 @@ class FlowerService implements FEService {
         return stats;
     }
 
-    async draw3DFlower(genome: string): Promise<string> {
+    async draw3DFlower(genome: string, sex: 'male' | 'female' | 'both'): Promise<string> {
         this.ensureInitialized();
         const flowerId = `flower-${Math.random().toString(36).substring(2, 9)}`;
-        const gltfString = await this.service.draw3DFlower(genome, flowerId, "both");
+        const gltfString = await this.service.draw3DFlower(genome, flowerId, sex);
         return gltfString;
+    }
+
+    async drawEmissive3DFlower(genome: string, sex: 'male' | 'female' | 'both'): Promise<string> {
+        this.ensureInitialized();
+        const flowerId = `flower-${Math.random().toString(36).substring(2, 9)}`;
+        return await this.service.drawEmissive3DFlower(genome, flowerId, sex);
     }
 
     async drawFlower(genome: string): Promise<{genome: string, image: string}> {
         this.ensureInitialized();
         return await this.service.drawFlower(genome);
+    }
+
+    async drawPetals(genome: string): Promise<{ genome: string; image: string; }> {
+        this.ensureInitialized();
+        return await this.service.drawPetals(genome);
+    }
+
+    async drawPetalLayer(genome: string, layer: number): Promise<{ genome: string; image: string; }> {
+        this.ensureInitialized();
+        return await this.service.drawPetalLayer(genome, layer);
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,12 +164,19 @@ export type ActorDelta = ActorAddDelta | ActorUpdateDelta | ActorRemoveDelta;
 export interface FEService {
     initialize(): Promise<void>;
     setParams(params: FEParams): void;
+    getParams(): FEParams;
     makeFlower(): Promise<{genome: string, image: string}>;
+    makePetals(): Promise<{ genome: string; image: string }>;
+    makePetalLayer(layer: number): Promise<{ genome: string; image: string }>;
+    makeStem(): Promise<{ genome: string; image: string }>;
     reproduce(father: string, mother: string): Promise<{genome: string, image: string}>;
     mutate(original: string, addNodeRate?: number, addConnRate?: number, removeConnRate?: number, perturbWeightsRate?: number, enableRate?: number, disableRate?: number, actTypeRate?: number): Promise<{genome: string, image: string}>;
     getFlowerStats(genome: string, humidity?: number, temperature?: number, altitude?: number, terrainType?: number): Promise<FlowerGenomeStats>;
-    draw3DFlower(genome: string): Promise<string>;
     drawFlower(genome: string): Promise<{genome: string, image: string}>;
+    drawPetals(genome: string): Promise<{ genome: string; image: string }>;
+    drawPetalLayer(genome: string, layer: number): Promise<{ genome: string; image: string }>;
+    draw3DFlower(genome: string, sex: 'male' | 'female' | 'both'): Promise<string>;
+    drawEmissive3DFlower(genome: string, sex: 'male' | 'female' | 'both'): Promise<string>;
 }
 
 export interface FEParams {


### PR DESCRIPTION
This commit enhances the 3D flower viewer with a new feature and improves the underlying service abstractions.

- **Emissive Material Toggle:** Added a checkbox in the Flower Details panel that allows users to render the 3D flower model with emissive materials, causing parts of the flower to glow. This utilizes the `drawEmissive3DFlower` function from the WASM genetics engine.
- **Type Definitions:** The TypeScript declaration file for the `@cristianglezm/flower-evolver-wasm` package (`src/flower-evolver-wasm.d.ts`) has been updated to be a complete representation of the package's API, including the `make3DFlower` and `makeEmissive3DFlower` methods.
- **Documentation:** Updated `README.md` and `Planning.md` to reflect the new 3D viewer feature.