### PR TITLE
feat(SeedBank): Introduce Seed Bank to save and reuse champion flowers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A dynamic garden simulation where flowers evolve under the pressure of insects a
 -   **Dynamic Weather & Seasons**: Experience a living environment with four distinct seasons (Spring, Summer, Autumn, Winter) that cyclically affect temperature and humidity. Be prepared for unpredictable weather events like heatwaves, cold snaps, heavy rain, and droughts that create new evolutionary pressures.
 -   **High-Performance Canvas Rendering**: The entire simulation grid is rendered on a single `<canvas>` element, ensuring smooth performance even with hundreds of entities.
 -   **User Goals & Scenarios (Challenges)**: Engage with a set of predefined challenges that track your progress across multiple playthroughs. Challenges cover survival (e.g., *Ancient Bloom*), predation (*Apex Predator*), ecosystem balance (*Circle of Life*), population milestones (*The Swarm*), and genetic evolution (*Poison Garden*).
+-   **Seed Bank**: Automatically saves the genomes of "champion" flowers—the longest-lived, most toxic, and most healing—to a persistent database. These champions are then used to repopulate the garden after a collapse, ensuring genetic resilience. Users can view these champions, download their genomes, or clear the bank to start fresh.
 -   **Data Visualization & Analytics**: Monitor the health and evolution of your garden over time with dynamic, real-time charts. Track population dynamics, key ecosystem events, the average expression of genetic traits, application performance, and a new **Environment chart** that visualizes the history of temperature and humidity changes.
 -   **Advanced Notification System**:
     -   **Real-time Event Log & Environment Display**: A retro, terminal-style log in the header provides a non-intrusive feed of all simulation events, complemented by a real-time display of the current season, temperature, humidity, and any active weather events.
@@ -110,10 +111,11 @@ The visual variety and evolutionary mechanics are powered by a custom WebAssembl
     -   `src/components/FlowerDetailsPanel.tsx`: UI that displays the stats of the selected flower. It handles pausing the simulation when its "View in 3D" button is clicked.
     -   `src/components/Flower3DViewer.tsx`: A React-Three-Fiber component that renders the 3D flower model.
     -   `src/components/Modal.tsx`: A generic modal component.
-    -   `src/components/DataPanel.tsx`: The main UI for the slide-out panel containing challenges and analytics, with a tabbed interface.
+    -   `src/components/DataPanel.tsx`: The main UI for the slide-out panel containing challenges, analytics, and the Seed Bank, with a tabbed interface.
     -   `src/components/ChallengesPanel.tsx`: Renders the list of challenges and their progress from the `challengeStore`.
     -   `src/components/ChartsPanel.tsx`: Renders all the data visualization charts using data from the `analyticsStore`.
     -   `src/components/Chart.tsx`: A reusable wrapper component for the `echarts-for-react` library.
+    -   `src/components/SeedBankPanel.tsx`: Renders the champion flowers saved in the Seed Bank. Allows users to view a 3D model of the champions, download their genomes, and clear the database.
     -   `src/components/Toast.tsx`: Renders a single toast notification with a message and icon.
     -   `src/components/ToastContainer.tsx`: Manages the on-screen layout and rendering of all active toasts.
     -   `src/services/flowerService.ts`: A TypeScript singleton wrapper for the WASM module.

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -31,10 +31,11 @@ test.describe('Data Panel', () => {
         await dataPanel.close();
     });
 
-    test('should switch between Challenges and Analytics tabs', async ({ page }) => {
+    test('should switch between Challenges, Analytics, and Seed Bank tabs', async ({ page }) => {
         const dataPanel = new DataPanelController(page);
         await dataPanel.open();
         await dataPanel.goToAnalyticsTab();
+        await dataPanel.goToSeedBankTab();
         await dataPanel.goToChallengesTab();
     });
 });

--- a/e2e/controllers/DataPanelController.ts
+++ b/e2e/controllers/DataPanelController.ts
@@ -6,7 +6,7 @@ export class DataPanelController {
 
   constructor(page: Page) {
     this.page = page;
-    this.panel = page.locator('aside:has-text("Challenges & Analytics")');
+    this.panel = page.locator('aside:has-text("Data & Records")');
   }
 
   async open() {
@@ -27,6 +27,10 @@ export class DataPanelController {
     return this.panel.getByRole('tab', { name: 'Analytics' });
   }
 
+  getSeedBankTab() {
+    return this.panel.getByRole('tab', { name: 'Seed Bank' });
+  }
+
   async goToChallengesTab() {
     await this.getChallengesTab().click();
     // Check for a known challenge title to confirm the tab is loaded.
@@ -38,5 +42,11 @@ export class DataPanelController {
     // Charts are rendered inside a canvas, so we can't get text.
     // Instead, we verify that the canvas element for the charts is visible.
     await expect(this.panel.locator('canvas').first()).toBeVisible();
+  }
+
+  async goToSeedBankTab() {
+    await this.getSeedBankTab().click();
+    // Check for some static text to confirm the tab is loaded.
+    await expect(this.page.getByText('The Seed Bank is empty.')).toBeVisible();
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -448,7 +448,12 @@ export default function App(): React.ReactNode {
             </button>
       </div>
       
-      <DataPanel isOpen={isDataPanelOpen} onClose={() => setIsDataPanelOpen(false)} />
+      <DataPanel 
+        isOpen={isDataPanelOpen} 
+        onClose={() => setIsDataPanelOpen(false)}
+        isRunning={isRunning}
+        setIsRunning={setIsRunning}
+      />
       <FullEventLogPanel isOpen={isFullLogOpen} onClose={handleCloseFullLog} />
 
       {/* Controls Panel Overlay */}

--- a/src/components/DataPanel.test.tsx
+++ b/src/components/DataPanel.test.tsx
@@ -10,12 +10,16 @@ vi.mock('./ChallengesPanel', () => ({
 vi.mock('./ChartsPanel', () => ({
   ChartsPanel: () => <div data-testid="charts-panel-mock" />,
 }));
+vi.mock('./SeedBankPanel', () => ({
+  SeedBankPanel: () => <div data-testid="seed-bank-panel-mock" />,
+}));
 
 describe('DataPanel', () => {
   const mockOnClose = vi.fn();
+  const mockSetIsRunning = vi.fn();
 
   it('is visible when isOpen is true', () => {
-    render(<DataPanel isOpen={true} onClose={mockOnClose} />);
+    render(<DataPanel isOpen={true} onClose={mockOnClose} isRunning={false} setIsRunning={mockSetIsRunning} />);
     const panel = screen.getByRole('complementary'); // <aside> role
     expect(panel).toBeInTheDocument();
     expect(panel).not.toHaveClass('-translate-x-full');
@@ -24,7 +28,7 @@ describe('DataPanel', () => {
 
   it('is hidden when isOpen is false', () => {
     // Note: The component uses translate-x-full to hide, so it's still in the DOM.
-    render(<DataPanel isOpen={false} onClose={mockOnClose} />);
+    render(<DataPanel isOpen={false} onClose={mockOnClose} isRunning={false} setIsRunning={mockSetIsRunning} />);
     const panel = screen.getByRole('complementary');
     expect(panel).toHaveClass('-translate-x-full');
     expect(panel).not.toHaveClass('translate-x-0');
@@ -32,7 +36,7 @@ describe('DataPanel', () => {
 
   it('calls onClose when the close button is clicked', () => {
     mockOnClose.mockClear();
-    render(<DataPanel isOpen={true} onClose={mockOnClose} />);
+    render(<DataPanel isOpen={true} onClose={mockOnClose} isRunning={false} setIsRunning={mockSetIsRunning} />);
     
     const closeButton = screen.getByLabelText('Close data panel');
     fireEvent.click(closeButton);
@@ -42,7 +46,7 @@ describe('DataPanel', () => {
 
   it('calls onClose when the overlay is clicked', () => {
     mockOnClose.mockClear();
-    render(<DataPanel isOpen={true} onClose={mockOnClose} />);
+    render(<DataPanel isOpen={true} onClose={mockOnClose} isRunning={false} setIsRunning={mockSetIsRunning} />);
     
     const panel = screen.getByRole('complementary');
     const overlay = panel.previousElementSibling;
@@ -53,34 +57,38 @@ describe('DataPanel', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
-  it('switches between Challenges and Analytics tabs', () => {
-    render(<DataPanel isOpen={true} onClose={mockOnClose} />);
+  it('switches between all three tabs', () => {
+    render(<DataPanel isOpen={true} onClose={mockOnClose} isRunning={false} setIsRunning={mockSetIsRunning} />);
 
     const challengesTab = screen.getByRole('tab', { name: /Challenges/i });
     const analyticsTab = screen.getByRole('tab', { name: /Analytics/i });
+    const seedBankTab = screen.getByRole('tab', { name: /Seed Bank/i });
 
     // Initially, Challenges should be active
     expect(challengesTab).toHaveAttribute('aria-selected', 'true');
-    expect(analyticsTab).toHaveAttribute('aria-selected', 'false');
     expect(screen.getByTestId('challenges-panel-mock')).toBeVisible();
     expect(screen.queryByTestId('charts-panel-mock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('seed-bank-panel-mock')).not.toBeInTheDocument();
 
     // Click Analytics tab
     fireEvent.click(analyticsTab);
-
-    // Now, Analytics should be active
-    expect(challengesTab).toHaveAttribute('aria-selected', 'false');
     expect(analyticsTab).toHaveAttribute('aria-selected', 'true');
     expect(screen.queryByTestId('challenges-panel-mock')).not.toBeInTheDocument();
     expect(screen.getByTestId('charts-panel-mock')).toBeVisible();
+    expect(screen.queryByTestId('seed-bank-panel-mock')).not.toBeInTheDocument();
 
+    // Click Seed Bank tab
+    fireEvent.click(seedBankTab);
+    expect(seedBankTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByTestId('challenges-panel-mock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('charts-panel-mock')).not.toBeInTheDocument();
+    expect(screen.getByTestId('seed-bank-panel-mock')).toBeVisible();
+    
     // Click Challenges tab again
     fireEvent.click(challengesTab);
-    
-    // Should switch back
     expect(challengesTab).toHaveAttribute('aria-selected', 'true');
-    expect(analyticsTab).toHaveAttribute('aria-selected', 'false');
     expect(screen.getByTestId('challenges-panel-mock')).toBeVisible();
     expect(screen.queryByTestId('charts-panel-mock')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('seed-bank-panel-mock')).not.toBeInTheDocument();
   });
 });

--- a/src/components/DataPanel.tsx
+++ b/src/components/DataPanel.tsx
@@ -1,16 +1,19 @@
 import React, { useState } from 'react';
 import { ChallengesPanel } from './ChallengesPanel';
 import { ChartsPanel } from './ChartsPanel';
-import { XIcon, LineChartIcon, TrophyIcon } from './icons';
+import { SeedBankPanel } from './SeedBankPanel';
+import { XIcon, LineChartIcon, TrophyIcon, SeedlingIcon } from './icons';
 
 interface DataPanelProps {
     isOpen: boolean;
     onClose: () => void;
+    isRunning: boolean;
+    setIsRunning: (running: boolean) => void;
 }
 
-type ActiveTab = 'challenges' | 'analytics';
+type ActiveTab = 'challenges' | 'analytics' | 'seedBank';
 
-export const DataPanel: React.FC<DataPanelProps> = ({ isOpen, onClose }) => {
+export const DataPanel: React.FC<DataPanelProps> = ({ isOpen, onClose, isRunning, setIsRunning }) => {
     const [activeTab, setActiveTab] = useState<ActiveTab>('challenges');
 
     return (
@@ -25,7 +28,7 @@ export const DataPanel: React.FC<DataPanelProps> = ({ isOpen, onClose }) => {
             <aside className={`fixed top-0 left-0 h-full bg-surface z-40 transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : '-translate-x-full'} w-full max-w-sm`}>
                 <div className="h-full flex flex-col">
                     <header className="flex items-center justify-between p-2 bg-background text-primary-light">
-                        <h2 className="text-xl font-bold ml-2">Challenges & Analytics</h2>
+                        <h2 className="text-xl font-bold ml-2">Data & Records</h2>
                         <button
                             onClick={onClose}
                             className="p-1 hover:bg-black/20 rounded-full"
@@ -54,10 +57,21 @@ export const DataPanel: React.FC<DataPanelProps> = ({ isOpen, onClose }) => {
                                 <LineChartIcon className="w-5 h-5 mr-2" />
                                 Analytics
                             </button>
+                            <button
+                                onClick={() => setActiveTab('seedBank')}
+                                className={`flex-1 flex items-center justify-center px-3 py-2 text-sm font-medium rounded-md ${activeTab === 'seedBank' ? 'bg-accent-green/50 text-white' : 'text-secondary hover:bg-surface-hover/50'} cursor-pointer`}
+                                role="tab"
+                                aria-selected={activeTab === 'seedBank'}
+                            >
+                                <SeedlingIcon className="w-5 h-5 mr-2" />
+                                Seed Bank
+                            </button>
                         </nav>
                     </div>
                     <div className="grow overflow-y-auto">
-                        {activeTab === 'challenges' ? <ChallengesPanel /> : <ChartsPanel />}
+                        {activeTab === 'challenges' && <ChallengesPanel />}
+                        {activeTab === 'analytics' && <ChartsPanel />}
+                        {activeTab === 'seedBank' && <SeedBankPanel isRunning={isRunning} setIsRunning={setIsRunning} />}
                     </div>
                 </div>
             </aside>

--- a/src/components/SeedBankPanel.tsx
+++ b/src/components/SeedBankPanel.tsx
@@ -1,0 +1,202 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { db } from '../services/db';
+import type { SeedBankEntry } from '../types';
+import { LoaderIcon, Trash2Icon, DownloadIcon, View3DIcon } from './icons';
+import { Modal } from './Modal';
+import { Flower3DViewer } from './Flower3DViewer';
+import { flowerService } from '../services/flowerService';
+
+const ConfirmationModal: React.FC<{ onConfirm: () => void; onCancel: () => void; }> = ({ onConfirm, onCancel }) => (
+    <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={onCancel}>
+        <div className="bg-surface border border-border rounded-lg shadow-xl w-full max-w-md p-6" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-xl font-bold text-primary-light">Clear Seed Bank?</h3>
+            <p className="text-secondary my-4">This will remove all saved champion flowers and cannot be undone. New flowers will be completely random until new champions are saved.</p>
+            <div className="flex justify-end space-x-4">
+                <button onClick={onCancel} className="px-4 py-2 bg-surface-hover hover:bg-border/20 text-primary-light font-semibold rounded-md transition-colors">Cancel</button>
+                <button onClick={onConfirm} className="px-4 py-2 bg-accent-red/80 hover:bg-accent-red text-white font-semibold rounded-md transition-colors">Confirm & Clear</button>
+            </div>
+        </div>
+    </div>
+);
+
+interface SeedBankCardProps {
+    entry: SeedBankEntry;
+    onDownload: (genome: string, id: string) => void;
+    onView3D: (genome: string, sex: 'male' | 'female' | 'both') => void;
+}
+
+const SeedBankCard: React.FC<SeedBankCardProps> = ({ entry, onDownload, onView3D }) => {
+    let title = '';
+    let value = '';
+
+    switch (entry.category) {
+        case 'longestLived':
+            title = 'Longest Lived';
+            value = `${entry.value} ticks`;
+            break;
+        case 'mostToxic':
+            title = 'Most Toxic';
+            value = `${(entry.value * 100).toFixed(0)}% Toxicity`;
+            break;
+        case 'mostHealing':
+            title = 'Most Healing';
+            // Since healing is negative, multiply by -1 for display
+            value = `${(entry.value * -100).toFixed(0)}% Healing`;
+            break;
+    }
+    
+    return (
+        <div className="bg-surface-hover/50 rounded-lg p-3 flex flex-col">
+            <h4 className="font-semibold text-primary">{title}</h4>
+            <p className="text-sm text-accent-yellow font-bold mb-2">{value}</p>
+            <div className="bg-black/50 rounded flex items-center justify-center p-2 aspect-square">
+                 <img src={entry.imageData} alt={`Champion flower for ${title}`} className="w-full h-full object-contain"/>
+            </div>
+            <div className="grid grid-cols-2 gap-2 mt-3 pt-3 border-t border-border/50">
+                <button 
+                    onClick={() => onDownload(entry.genome, entry.category)} 
+                    className="flex items-center justify-center gap-2 text-sm p-2 bg-surface-hover rounded-md hover:bg-border/20 transition-colors"
+                    title="Download genome as a JSON file"
+                >
+                    <DownloadIcon className="w-4 h-4" />
+                    Download
+                </button>
+                 <button 
+                    onClick={() => onView3D(entry.genome, entry.sex || 'both')} // Fallback for old saves
+                    className="flex items-center justify-center gap-2 text-sm p-2 bg-surface-hover rounded-md hover:bg-border/20 transition-colors"
+                    title="View 3D model"
+                >
+                    <View3DIcon className="w-4 h-4" />
+                    View 3D
+                </button>
+            </div>
+        </div>
+    );
+};
+
+interface SeedBankPanelProps {
+    isRunning: boolean;
+    setIsRunning: (running: boolean) => void;
+}
+
+export const SeedBankPanel: React.FC<SeedBankPanelProps> = ({ isRunning, setIsRunning }) => {
+    const [champions, setChampions] = useState<SeedBankEntry[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [showConfirmModal, setShowConfirmModal] = useState(false);
+    
+    // State for 3D Viewer
+    const [is3DViewerOpen, setIs3DViewerOpen] = useState(false);
+    const [gltfString, setGltfString] = useState<string | null>(null);
+    const [isLoading3D, setIsLoading3D] = useState(false);
+    const [modalTitle, setModalTitle] = useState('');
+    const wasRunningRef = useRef(false);
+
+    const fetchChampions = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const data = await db.seedBank.toArray();
+            setChampions(data);
+        } catch (error) {
+            console.error("Failed to fetch from seed bank:", error);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchChampions();
+    }, [fetchChampions]);
+
+    const handleClearBank = async () => {
+        try {
+            await db.seedBank.clear();
+            setChampions([]);
+        } catch (error) {
+            console.error("Failed to clear seed bank:", error);
+        } finally {
+            setShowConfirmModal(false);
+        }
+    };
+    
+    const handleDownloadGenome = useCallback((genome: string, id: string) => {
+        const link = document.createElement('a');
+        link.download = `champion_${id}.json`;
+        link.href = 'data:text/json;charset=utf-8,' + encodeURIComponent(genome);
+        link.click();
+    }, []);
+
+    const handleView3D = async (genome: string, sex: 'male'|'female'|'both') => {
+        wasRunningRef.current = isRunning;
+        setIsRunning(false);
+
+        setIsLoading3D(true);
+        setGltfString(null);
+        setIs3DViewerOpen(true);
+        setModalTitle('Generating 3D Model...');
+        
+        try {
+            const gltf = await flowerService.draw3DFlower(genome, sex);
+            setGltfString(gltf);
+            setModalTitle('Champion Flower 3D Model');
+        } catch (error) {
+            console.error("Failed to generate 3D model:", error);
+            setIs3DViewerOpen(false);
+            setIsRunning(wasRunningRef.current);
+        } finally {
+            setIsLoading3D(false);
+        }
+    };
+    
+    const handleClose3DViewer = () => {
+        setIs3DViewerOpen(false);
+        setIsRunning(wasRunningRef.current);
+    };
+
+
+    return (
+        <div className="p-4 space-y-4">
+            <div className="flex items-center justify-between">
+                <p className="text-sm text-secondary">Champions are saved here to repopulate the garden after a collapse.</p>
+                <button 
+                    onClick={() => setShowConfirmModal(true)}
+                    className="flex items-center px-3 py-1.5 bg-accent-red/20 hover:bg-accent-red/40 text-accent-red font-semibold rounded-md transition-colors text-sm"
+                    title="Clear all saved champion genomes"
+                >
+                    <Trash2Icon className="w-4 h-4 mr-2" />
+                    Clear
+                </button>
+            </div>
+            
+            {isLoading ? (
+                <div className="flex justify-center items-center h-48">
+                    <LoaderIcon className="w-8 h-8 animate-spin text-tertiary" />
+                </div>
+            ) : champions.length === 0 ? (
+                <div className="text-center text-secondary py-12">
+                    <p>The Seed Bank is empty.</p>
+                    <p className="text-sm">Let flowers complete their lifecycle to find new champions!</p>
+                </div>
+            ) : (
+                <div className="grid grid-cols-1 gap-4">
+                    {champions.map(entry => <SeedBankCard key={entry.category} entry={entry} onDownload={handleDownloadGenome} onView3D={handleView3D} />)}
+                </div>
+            )}
+
+            {showConfirmModal && <ConfirmationModal onConfirm={handleClearBank} onCancel={() => setShowConfirmModal(false)} />}
+            
+            <Modal
+                isOpen={is3DViewerOpen}
+                onClose={handleClose3DViewer}
+                title={modalTitle}
+            >
+                {isLoading3D || !gltfString ? (
+                    <div className="flex items-center justify-center h-full">
+                        <LoaderIcon className="w-12 h-12 animate-spin text-tertiary" />
+                    </div>
+                ) : (
+                    <Flower3DViewer gltfString={gltfString} />
+                )}
+            </Modal>
+        </div>
+    );
+};

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -65,6 +65,15 @@ export const DownloadIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => 
     </svg>
 );
 
+export const View3DIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+        <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+        <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
+        <line x1="12" y1="22.08" x2="12" y2="12"></line>
+    </svg>
+);
+
+
 export const SettingsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
         <circle cx="12" cy="12" r="3"></circle>
@@ -172,5 +181,22 @@ export const WindIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
         <path d="M9.59 4.59A2 2 0 1 1 11 8H2"></path>
         <path d="M12.5 16H3.74a2 2 0 1 0 0 4h8.76"></path>
         <path d="M19.5 12H10.26a2 2 0 1 1 0-4h9.24"></path>
+    </svg>
+);
+
+export const SeedlingIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+        <path d="M4 20h16" />
+        <path d="M10 20v-6c0-1.1.9-2 2-2s2 .9 2 2v6" />
+        <path d="M12 12a4 4 0 0 0 0-8c-2.2 0-4 1.8-4 4" />
+    </svg>
+);
+
+export const Trash2Icon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+        <path d="M3 6h18" />
+        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+        <line x1="10" y1="11" x2="10" y2="17" />
+        <line x1="14" y1="11" x2="14" y2="17" />
     </svg>
 );

--- a/src/lib/simulationEngine.test.ts
+++ b/src/lib/simulationEngine.test.ts
@@ -3,6 +3,16 @@ import { SimulationEngine } from './simulationEngine';
 import { DEFAULT_SIM_PARAMS, SEED_HEALTH } from '../constants';
 import type { FEService, Flower, Grid, CellContent, ActorUpdateDelta, ActorAddDelta, FlowerSeed } from '../types';
 
+vi.mock('../services/db', () => ({
+  db: {
+    seedBank: {
+      get: vi.fn().mockResolvedValue(undefined),
+      put: vi.fn().mockResolvedValue(undefined),
+      toArray: vi.fn().mockResolvedValue([]),
+    },
+  },
+}));
+
 const mockFlowerService: FEService = {
     initialize: vi.fn().mockResolvedValue(undefined),
     setParams: vi.fn(),

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,12 +1,14 @@
 import { Dexie, type Table } from 'dexie';
-import type { Flower } from '../types';
+import type { Flower, SeedBankEntry } from '../types';
 
 export class EvoGardenDB extends Dexie {
   savedFlowers!: Table<Flower, string>;
+  seedBank!: Table<SeedBankEntry, string>;
   constructor() {
     super('EvoGardenDatabase');
-    this.version(1).stores({
-      savedFlowers: 'id' 
+    this.version(2).stores({
+      savedFlowers: 'id',
+      seedBank: 'category',
     });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -328,3 +328,15 @@ export interface TickSummary {
     season: Season;
     weatherEvent: WeatherEventType;
 }
+
+// --- Seed Bank ---
+
+export type SeedBankCategory = 'longestLived' | 'mostToxic' | 'mostHealing';
+
+export interface SeedBankEntry {
+    category: SeedBankCategory;
+    genome: string;
+    value: number;
+    imageData: string;
+    sex: 'male' | 'female' | 'both';
+}


### PR DESCRIPTION
This commit introduces a major new feature: the Seed Bank. This system automatically saves "champion" flowers—those that achieve records for longevity, toxicity, or healing properties—into a persistent IndexedDB store. These champions can then be viewed and are used to repopulate the garden after a collapse, preserving valuable genetic traits across simulations.

-   **New "Seed Bank" Tab:** The Data Panel has been updated with a third tab, "Seed Bank," and its title is now "Data & Records."
-   **Automatic Champion Saving:** The simulation engine now tracks the longest-lived, most toxic, and most healing flowers. When a flower dies, it's checked against the current records. If it's a new champion, its genome, stats, and a rendered image are saved to the Seed Bank.
-   **Garden Repopulation:** When the garden's flower population collapses, the simulation will now use genomes from the Seed Bank to seed the new generation, rather than starting from random genomes.
-   **Champion Viewing:** In the Seed Bank panel, users can see the current champion for each category, download their genome as a JSON file, and view an interactive 3D model of the flower.
-   **Pause on 3D View:** Opening the 3D viewer now pauses the simulation to conserve resources and allow for focused inspection. The simulation resumes when the viewer is closed.
-   **Clear Functionality:** A "Clear" button with a confirmation modal allows users to wipe the Seed Bank and start fresh.

-   **`SeedBankPanel.tsx`:** A new component to display champions, handle user interactions (download, 3D view, clear), and manage its own state (loading, modals).
-   **`simulationEngine.ts`:**
    -   Logic added to load champions from the database on startup.
    -   A new `_checkAndSaveChampion` method is called for any flower that dies to see if it sets a new record.
    -   The repopulation logic for a collapsed ecosystem now queries the Seed Bank.
-   **`db.ts`:** The Dexie database schema is updated to version 2, adding a `seedBank` table to store `SeedBankEntry` objects.
-   **`DataPanel.tsx`:** Updated to include the third tab and pass `isRunning`/`setIsRunning` props down to the `SeedBankPanel` to control the simulation state.
-   **Testing:** End-to-end and unit tests for the Data Panel have been updated to reflect the new tab and functionality. Mocks for the database have been added to the simulation engine tests.
-   **Icons:** New icons for `Seedling`, `Trash2`, and `View3D` have been added.