### PR TITLE
fix(insects2indexeddb): Migrate insect state from localStorage to IndexedDB

### DIFF
--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,14 +1,21 @@
 import { Dexie, type Table } from 'dexie';
-import type { Flower, SeedBankEntry } from '../types';
+import type { Flower, Insect, SeedBankEntry } from '../types';
 
 export class EvoGardenDB extends Dexie {
   savedFlowers!: Table<Flower, string>;
+  savedInsects!: Table<Insect, string>;
   seedBank!: Table<SeedBankEntry, string>;
   constructor() {
     super('EvoGardenDatabase');
     this.version(2).stores({
       savedFlowers: 'id',
       seedBank: 'category',
+    });
+    // Version 3 adds the savedInsects table and must re-declare existing tables.
+    this.version(3).stores({
+      savedFlowers: 'id',
+      seedBank: 'category',
+      savedInsects: 'id'
     });
   }
 }


### PR DESCRIPTION
This commit refactors the persistence layer to address a critical scalability issue where saving the simulation would fail due to localStorage's size limitations (typically around 5-10MB).

Previously, all actor data, including insects, was serialized and stored directly in localStorage. In simulations with a large number of insects, the resulting JSON string would exceed the storage quota, causing the save operation to fail and preventing users from preserving their progress.

To resolve this, this change migrates the storage of detailed insect data to a new `savedInsects` table in IndexedDB, which is designed for handling larger datasets. LocalStorage is now only used to store a "skeleton" metadata object with lightweight placeholders for each actor.

Key changes:
- A `savedInsects` table was added to the Dexie (IndexedDB) schema.
- The saving process now separates insects from the main state object, storing them in IndexedDB and leaving placeholders in localStorage.
- A new `rehydrateGrid` function has been introduced to merge the metadata from localStorage with the full actor data (both flowers and insects) from IndexedDB upon loading.
- Error handling and state clearing logic have been updated to include the new `savedInsects` table.

This new approach allows the simulation to support a significantly larger number of actors, making long-term and complex ecological simulations viable without the risk of data loss due to storage limitations.