### PR TITLE
refactor(flower-creation): Implement queueing and cancellation for flower worker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { EventLog } from './components/EventLog';
 import { useEventLogStore } from './stores/eventLogStore';
 import { FullEventLogPanel } from './components/FullEventLogPanel';
 import { EnvironmentDisplay } from './components/EnvironmentDisplay';
+import { WorkerStatusDisplay } from './components/WorkerStatusDisplay';
 
 const META_SAVE_KEY = 'evoGarden-savedState-meta';
 const INIT_TIMEOUT_MS = 15000; // 15 seconds for initialization and loading
@@ -375,7 +376,10 @@ export default function App(): React.ReactNode {
             <LogoIcon className="h-8 w-8 text-tertiary" />
             <div className="flex flex-col">
                 <h1 className="text-2xl font-bold tracking-wider text-tertiary">Evo<span className="text-accent">Garden</span></h1>
-                <EnvironmentDisplay summary={latestSummary} />
+                 <div className="flex items-center space-x-4">
+                    <EnvironmentDisplay summary={latestSummary} />
+                    <WorkerStatusDisplay pendingRequests={latestSummary?.pendingFlowerRequests} />
+                </div>
             </div>
         </div>
         <div className="w-1/3 max-w-sm">

--- a/src/components/ChartsPanel.tsx
+++ b/src/components/ChartsPanel.tsx
@@ -42,7 +42,7 @@ export const ChartsPanel: React.FC = () => {
     const history = useAnalyticsStore(state => state.history);
     
     // State to hold legend visibility for each chart
-    const [performanceLegend, setPerformanceLegend] = useState<Record<string, boolean>>({ 'Tick Time (Worker)': true, 'Render Time (UI)': true });
+    const [performanceLegend, setPerformanceLegend] = useState<Record<string, boolean>>({ 'Tick Time (Worker)': true, 'Render Time (UI)': true, 'Pending Requests': true });
     const [populationLegend, setPopulationLegend] = useState<Record<string, boolean>>({ 'Flowers': true, 'Insects': true, 'Birds': true, 'Eagles': true, 'Herbicide Planes': true, 'Herbicide Smokes': true, 'Eggs': true });
     const [eventsLegend, setEventsLegend] = useState<Record<string, boolean>>({ 'Reproductions': true, 'Insects Eaten': true, 'Eggs Laid': true, 'Insects Born': true, 'Eggs Eaten': true, 'Died of Old Age': true });
     const [traitsLegend, setTraitsLegend] = useState<Record<string, boolean>>({ 'Avg Health': true, 'Max Health': true, 'Avg Stamina': true, 'Max Stamina': true, 'Avg Maturation': true, 'Avg Nutrient Efficiency': true, 'Max Toxicity': true });
@@ -86,13 +86,28 @@ export const ChartsPanel: React.FC = () => {
         const ticks = history.map(h => h.tick);
         return {
             ...baseChartOptions,
-            title: { text: 'Performance (ms)', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
-            legend: { data: ['Tick Time (Worker)', 'Render Time (UI)'], top: 35, textStyle: { color: '#bbf7d0' }, selected: performanceLegend },
+            title: { text: 'Performance & Workload', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
+            legend: { data: ['Tick Time (Worker)', 'Render Time (UI)', 'Pending Requests'], top: 35, textStyle: { color: '#bbf7d0' }, selected: performanceLegend },
             xAxis: { ...baseChartOptions.xAxis, data: ticks },
-            yAxis: { ...baseChartOptions.yAxis, name: 'Milliseconds' },
+            yAxis: [
+                {
+                    ...(baseChartOptions.yAxis as object),
+                    type: 'value',
+                    name: 'Milliseconds',
+                    position: 'left',
+                },
+                {
+                    ...(baseChartOptions.yAxis as object),
+                    type: 'value',
+                    name: 'Count',
+                    position: 'right',
+                    splitLine: { show: false },
+                },
+            ],
             series: [
-                { name: 'Tick Time (Worker)', type: 'line', data: history.map(h => h.tickTimeMs.toFixed(2)), color: '#38b2ac' },
-                { name: 'Render Time (UI)', type: 'line', data: history.map(h => h.renderTimeMs.toFixed(2)), color: '#ed8936' },
+                { name: 'Tick Time (Worker)', type: 'line', yAxisIndex: 0, data: history.map(h => h.tickTimeMs.toFixed(2)), color: '#38b2ac' },
+                { name: 'Render Time (UI)', type: 'line', yAxisIndex: 0, data: history.map(h => h.renderTimeMs.toFixed(2)), color: '#ed8936' },
+                { name: 'Pending Requests', type: 'line', yAxisIndex: 1, data: history.map(h => h.pendingFlowerRequests), color: '#ed64a6' },
             ],
         };
     }, [history, performanceLegend]);

--- a/src/components/WorkerStatusDisplay.tsx
+++ b/src/components/WorkerStatusDisplay.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { LoaderIcon } from './icons';
+
+interface WorkerStatusDisplayProps {
+    pendingRequests?: number;
+}
+
+export const WorkerStatusDisplay: React.FC<WorkerStatusDisplayProps> = ({ pendingRequests }) => {
+    if (pendingRequests === undefined || pendingRequests === 0) {
+        return <div className="h-5"></div>; // Placeholder to prevent layout shift
+    }
+
+    return (
+        <div className="flex items-center space-x-2 text-xs text-secondary" title={`${pendingRequests} genetics tasks are queued for processing.`}>
+            <LoaderIcon className="w-4 h-4 text-accent-yellow animate-spin" />
+            <span>Genetics Worker: {pendingRequests} pending</span>
+        </div>
+    );
+};

--- a/src/lib/behaviors/flowerBehavior.test.ts
+++ b/src/lib/behaviors/flowerBehavior.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { processFlowerTick } from './flowerBehavior';
+import { processFlowerTick, processFlowerSeedTick } from './flowerBehavior';
 import type { Flower, Grid, CellContent, FlowerSeed } from '../../types';
 import { DEFAULT_SIM_PARAMS, FLOWER_STAMINA_COST_PER_TICK, FLOWER_TICK_COST_MULTIPLIER, FLOWER_EXPANSION_CHANCE, PROXIMITY_POLLINATION_CHANCE, SEED_HEALTH } from '../../constants';
 import { AsyncFlowerFactory } from '../asyncFlowerFactory';
@@ -12,6 +12,7 @@ describe('flowerBehavior', () => {
     let mockAsyncFlowerFactory: AsyncFlowerFactory;
     let requestNewFlower: Mock;
     let newActorQueue: CellContent[];
+    let claimedCellsThisTick: Set<string>;
 
     const mockFlower: Flower = {
         id: 'flower1', type: 'flower', x: 5, y: 5,
@@ -22,18 +23,22 @@ describe('flowerBehavior', () => {
         effects: { vitality: 1, agility: 1, strength: 1, intelligence: 1, luck: 1 }
     };
 
-    const mockSeed: FlowerSeed = { id: 'seed-1', type: 'flowerSeed', x: 4, y: 5, imageData: 'stem-image', health: SEED_HEALTH, maxHealth: SEED_HEALTH, age: 0 };
+    const mockSeed: FlowerSeed = { id: 'seed-1', type: 'flowerSeed', x: 0, y: 0, imageData: 'stem-image', health: SEED_HEALTH, maxHealth: SEED_HEALTH, age: 0 };
 
     beforeEach(() => {
         flower = { ...mockFlower };
         grid = Array.from({ length: 15 }, () => Array.from({ length: 15 }, () => []));
         grid[5][5].push(flower);
         
-        requestNewFlower = vi.fn().mockReturnValue(mockSeed);
+        // DYNAMIC MOCK: The mock now creates a seed based on the coordinates it receives.
+        requestNewFlower = vi.fn().mockImplementation((_state, x, y, _parent1, _parent2) => {
+            return { ...mockSeed, id: `seed-${x}-${y}`, x, y };
+        });
         mockAsyncFlowerFactory = new (AsyncFlowerFactory as any)();
         mockAsyncFlowerFactory.requestNewFlower = requestNewFlower;
 
         newActorQueue = [];
+        claimedCellsThisTick = new Set<string>();
     });
     
     const setupContext = () => ({
@@ -42,6 +47,7 @@ describe('flowerBehavior', () => {
         asyncFlowerFactory: mockAsyncFlowerFactory,
         currentTemperature: DEFAULT_SIM_PARAMS.temperature, // Default to a neutral temperature
         nextActorState: new Map<string, CellContent>(),
+        claimedCellsThisTick,
     });
 
     it('should age and consume stamina', () => {
@@ -70,18 +76,21 @@ describe('flowerBehavior', () => {
         expect(flower.stamina).toBe(initialStamina - expectedCost);
     });
 
-    it('should trigger expansion and queue a new FlowerSeed', () => {
+    it('should trigger expansion, queue a new FlowerSeed, and claim the cell', () => {
         vi.spyOn(Math, 'random').mockReturnValue(FLOWER_EXPANSION_CHANCE / 2);
         const context = setupContext();
         processFlowerTick(flower, context, newActorQueue);
         expect(requestNewFlower).toHaveBeenCalled();
         expect(requestNewFlower).toHaveBeenCalledWith(context.nextActorState, expect.any(Number), expect.any(Number), flower.genome);
         expect(newActorQueue.length).toBe(1);
-        expect(newActorQueue[0]).toEqual(mockSeed);
+        
+        const createdSeed = newActorQueue[0] as FlowerSeed;
+        // DYNAMIC ASSERTION: Check against the coordinates of the seed that was actually created.
+        expect(claimedCellsThisTick.has(`${createdSeed.x},${createdSeed.y}`)).toBe(true);
         vi.spyOn(Math, 'random').mockRestore();
     });
 
-    it('should trigger proximity pollination and queue a new FlowerSeed', () => {
+    it('should trigger proximity pollination, queue a new FlowerSeed, and claim the cell', () => {
         const neighborFlower: Flower = { ...mockFlower, id: 'flower2', x: 5, y: 6, genome: 'g2' };
         grid[6][5].push(neighborFlower);
         vi.spyOn(Math, 'random').mockReturnValue(PROXIMITY_POLLINATION_CHANCE / 2);
@@ -96,8 +105,82 @@ describe('flowerBehavior', () => {
             expect(requestNewFlower).toHaveBeenCalledWith(context.nextActorState, expect.any(Number), expect.any(Number), 'g2', 'g1');
         }
         expect(newActorQueue.length).toBe(1);
-        expect(newActorQueue[0]).toEqual(mockSeed);
+        const createdSeed = newActorQueue[0] as FlowerSeed;
+        expect(claimedCellsThisTick.has(`${createdSeed.x},${createdSeed.y}`)).toBe(true);
 
         vi.spyOn(Math, 'random').mockRestore();
+    });
+
+    it('should not attempt to expand into a cell that is already claimed', () => {
+        // Fill the entire grid with blockers to ensure that the global fallback search in 
+        // findCellForFlowerSpawn will not find any alternative spots.
+        for (let y = 0; y < grid.length; y++) {
+            for (let x = 0; x < grid[y].length; x++) {
+                // Don't put a blocker where the flower itself is located
+                if (x !== flower.x || y !== flower.y) {
+                    grid[y][x].push({ id: `blocker-${x}-${y}` } as CellContent);
+                }
+            }
+        }
+        
+        // Explicitly unblock one neighboring spot, making it the only empty cell on the grid.
+        const emptySpot = { x: 4, y: 5 };
+        grid[emptySpot.y][emptySpot.x] = [];
+
+        // Now, claim that single available spot for the current tick.
+        claimedCellsThisTick.add(`${emptySpot.x},${emptySpot.y}`);
+
+        // Force an expansion attempt.
+        vi.spyOn(Math, 'random').mockReturnValue(FLOWER_EXPANSION_CHANCE / 2); 
+
+        processFlowerTick(flower, setupContext(), newActorQueue);
+
+        // The expansion should fail because the only available cell was already claimed this tick.
+        expect(requestNewFlower).not.toHaveBeenCalled();
+        expect(newActorQueue.length).toBe(0);
+
+        vi.spyOn(Math, 'random').mockRestore();
+    });
+
+    describe('processFlowerSeedTick', () => {
+        let seed: FlowerSeed;
+        let mockAsyncFlowerFactory: AsyncFlowerFactory;
+        let cancelFlowerRequest: Mock;
+        let nextActorState: Map<string, CellContent>;
+
+        beforeEach(() => {
+            seed = { id: 'seed-1', type: 'flowerSeed', x: 1, y: 1, imageData: 'stem', health: 5, maxHealth: 5, age: 0 };
+            nextActorState = new Map();
+            nextActorState.set(seed.id, seed);
+            
+            cancelFlowerRequest = vi.fn();
+            mockAsyncFlowerFactory = new (AsyncFlowerFactory as any)();
+            mockAsyncFlowerFactory.cancelFlowerRequest = cancelFlowerRequest;
+        });
+
+        const setupSeedContext = () => ({
+            grid: [], // not needed for this test
+            params: DEFAULT_SIM_PARAMS,
+            asyncFlowerFactory: mockAsyncFlowerFactory,
+            currentTemperature: DEFAULT_SIM_PARAMS.temperature,
+            nextActorState,
+            claimedCellsThisTick: new Set<string>(), // Not used by seed tick, but required by context type
+        });
+
+        it('should age the seed', () => {
+            const context = setupSeedContext();
+            processFlowerSeedTick(seed, context);
+            expect(seed.age).toBe(1);
+            expect(nextActorState.has(seed.id)).toBe(true);
+            expect(cancelFlowerRequest).not.toHaveBeenCalled();
+        });
+
+        it('should be removed and send a cancellation request when health reaches zero', () => {
+            seed.health = 0;
+            const context = setupSeedContext();
+            processFlowerSeedTick(seed, context);
+            expect(nextActorState.has(seed.id)).toBe(false);
+            expect(cancelFlowerRequest).toHaveBeenCalledWith(seed.id);
+        });
     });
 });

--- a/src/lib/behaviors/herbicideSmokeBehavior.ts
+++ b/src/lib/behaviors/herbicideSmokeBehavior.ts
@@ -1,14 +1,16 @@
 import type { HerbicideSmoke, CellContent, Grid, SimulationParams, Flower, FlowerSeed } from '../../types';
 import { neighborVectors } from '../simulationUtils';
+import type { AsyncFlowerFactory } from '../asyncFlowerFactory';
 
 export interface HerbicideSmokeContext {
     grid: Grid;
     params: SimulationParams;
     nextActorState: Map<string, CellContent>;
+    asyncFlowerFactory: AsyncFlowerFactory;
 }
 
 export const processHerbicideSmokeTick = (smoke: HerbicideSmoke, context: HerbicideSmokeContext) => {
-    const { nextActorState, params } = context;
+    const { nextActorState, params, asyncFlowerFactory } = context;
     const { gridWidth, gridHeight, herbicideDamage, herbicideSmokeLifespan } = params;
 
     // 1. Apply damage to flowers and seeds in the same cell
@@ -19,6 +21,9 @@ export const processHerbicideSmokeTick = (smoke: HerbicideSmoke, context: Herbic
         target.health = Math.max(0, target.health - herbicideDamage);
         if (target.health <= 0) {
             nextActorState.delete(target.id); // Remove if destroyed
+            if (target.type === 'flowerSeed') {
+                asyncFlowerFactory.cancelFlowerRequest(target.id);
+            }
         }
     }
 

--- a/src/stores/analyticsStore.ts
+++ b/src/stores/analyticsStore.ts
@@ -47,6 +47,7 @@ export const useAnalyticsStore = create<AnalyticsState>()(
                     currentHumidity: summary.currentHumidity,
                     season: summary.season,
                     weatherEvent: summary.weatherEvent,
+                    pendingFlowerRequests: summary.pendingFlowerRequests,
                 };
                 
                 const newHistory = [...get().history, newPoint];

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,4 +1,3 @@
-
 import type { SavedCellActor, CellContent } from './actors';
 
 export type WindDirection = 'N' | 'NE' | 'E' | 'SE' | 'S' | 'SW' | 'W' | 'NW';
@@ -110,4 +109,13 @@ export interface TickSummary {
     currentHumidity: number;
     season: Season;
     weatherEvent: WeatherEventType;
+    pendingFlowerRequests: number;
+}
+
+export interface FlowerCreationRequest {
+    requestId: string;
+    x: number;
+    y: number;
+    parentGenome1?: string;
+    parentGenome2?: string;
 }

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,4 +1,5 @@
 
+
 import type { TickSummary, Season, WeatherEventType } from './base';
 
 export interface AppEvent {
@@ -77,6 +78,7 @@ export interface AnalyticsDataPoint {
     currentHumidity?: number;
     season?: Season;
     weatherEvent?: WeatherEventType;
+    pendingFlowerRequests: number;
 }
 
 export interface AnalyticsState {


### PR DESCRIPTION
This commit refactors the asynchronous flower creation process from a simple "fire-and-forget" model to a robust, queue-based system with cancellation support. This enhances simulation stability, performance, and observability.

Key changes:

- **Flower Worker Queue:**
  - The `flower.worker` now manages a request queue to process genetics tasks sequentially, preventing overload.
  - A cancellation queue is introduced, allowing the main thread to cancel pending tasks before or during processing, preventing wasted computation on flowers for seeds that have already been destroyed.

- **Request Cancellation Logic:**
  - `FlowerSeed` actors are now intrinsically linked to a creation request.
  - When a `FlowerSeed` is removed from the simulation (e.g., eaten, destroyed by herbicide, or fails to spawn), a cancellation request is dispatched to the worker.
  - The `AsyncFlowerFactory` is updated with methods to send cancellation messages and track pending requests.

- **Race Condition Prevention:**
  - A new `claimedCellsThisTick` set is managed by the simulation engine.
  - This prevents multiple flowers or other actors from attempting to spawn in the same cell during a single tick, resolving potential race conditions and ensuring deterministic spawning.

- **UI & Analytics:**
  - A new `WorkerStatusDisplay` component has been added to the main UI, showing the number of pending genetics tasks in real-time.
  - The "Performance" chart has been renamed to "Performance & Workload" and now includes a graph of pending requests, offering better insight into the simulation's background processing load.