### PR TITLE
feat(bird-scarcity-departure): Birds now leave when their food source is depleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evogarden",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A dynamic garden simulation where flowers evolve under the pressure of insects and birds. Watch a Darwinian battlefield unfold as flowers, insects, and birds interact in a delicate ecosystem, with visual traits driven by NEAT Algorithm.",
   "private": true,
   "type": "module",

--- a/src/lib/populationManager.ts
+++ b/src/lib/populationManager.ts
@@ -123,6 +123,17 @@ export class PopulationManager {
             this.herbicideCooldown = this.params.herbicideCooldown;
         }
 
+        // Birds leave when there's no food
+        const { insectCount, birdCount } = summary;
+        if (insectCount === 0 && birdCount > 0) {
+            const birds = Array.from(nextActorState.values()).filter(a => a.type === 'bird') as Bird[];
+            if (birds.length > 0) {
+                const birdToRemove = birds[0]; // Remove the first one found
+                nextActorState.delete(birdToRemove.id);
+                events.push({ message: '🐦 With no insects to hunt, a bird has left the garden.', type: 'info', importance: 'low' });
+            }
+        }
+
         return newActors;
     }
     


### PR DESCRIPTION
To create a more dynamic and realistic ecosystem, birds will now leave the garden if there are no insects available to hunt.

This change implements a mechanism where one bird is removed per tick as long as the total insect count is zero. This helps to naturally balance the predator population and prevents them from lingering when their food source is gone, which is especially relevant at the start of a season when insect populations are low.

An event is logged to notify the user when a bird leaves due to food scarcity.