### PR TITLE
feat(toxic-healing-charts): Modularize charts and add specialized flower tracking

### DIFF
--- a/Planning.md
+++ b/Planning.md
@@ -189,7 +189,7 @@ To avoid performance degradation as the number of actors grows, the `SimulationE
 -   **`GenericActorDetailsPanel.tsx`**: A fallback panel that displays basic information for any other actor type (birds, nutrients, etc.). Includes a "Track" button that utilizes the `useActorTracker` hook.
 -   **`Flower3DViewer.tsx`**: Renders a flower's 3D model using `@react-three/fiber`.
 -   **`DataPanel.tsx`**: A slide-out panel with a tabbed interface for `ChallengesPanel`, `ChartsPanel`, and `SeedBankPanel`.
--   **`ChartsPanel.tsx`**: Subscribes to `analyticsStore` and renders visualizations, including a new **Environment chart** showing the history of temperature and humidity.
+-   **`ChartsPanel.tsx`**: Subscribes to `analyticsStore` and renders visualizations.
 -   **`SeedBankPanel.tsx`**: Subscribes to the IndexedDB-based Seed Bank. Displays saved champion flowers with their stats and rendered image. Provides functionality to view a champion in 3D, download its genome, and clear the entire Seed Bank.
 -   **Header Components**:
     -   `StatusPanel.tsx`: A new container component in the header that orchestrates the `EnvironmentDisplay`, `WorkerStatusDisplay`, `EventLog`, and the `GlobalSearch` widget.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A dynamic garden simulation where flowers evolve under the pressure of insects a
 -   **High-Performance Canvas Rendering**: The entire simulation grid is rendered on a single `<canvas>` element, ensuring smooth performance even with hundreds of entities.
 -   **User Goals & Scenarios (Challenges)**: Engage with a set of predefined challenges that track your progress across multiple playthroughs. Challenges cover survival (e.g., *Ancient Bloom*), predation (*Apex Predator*), ecosystem balance (*Circle of Life*), population milestones (*The Swarm*), and genetic evolution (*Poison Garden*).
 -   **Seed Bank**: Automatically saves the genomes of "champion" flowers—the longest-lived, most toxic, and most healing—to a persistent database. These champions are then used to repopulate the garden after a collapse, ensuring genetic resilience. Users can view these champions, download their genomes, or clear the bank to start fresh.
--   **Data Visualization & Analytics**: Monitor the health and evolution of your garden over time with dynamic, real-time charts. Track population dynamics, key ecosystem events, the average expression of genetic traits, application performance, and a new **Environment chart** that visualizes the history of temperature and humidity changes.
+-   **Data Visualization & Analytics**: Monitor the health and evolution of your garden over time with dynamic, real-time charts. Track population dynamics (including specialized counts for **toxic** and **healing** flowers), key ecosystem events, the average expression of genetic traits, application performance, and a new Environment chart that visualizes the history of temperature and humidity changes.
 -   **Advanced Notification System & Status Display**:
     -   **Centralized Header**: A retro, terminal-style header provides a non-intrusive feed of all simulation events, complemented by a real-time display of the current season, temperature, humidity, and any active weather events.
     -   **Detailed Event Review**: Click the header log to open a full-screen, scrollable panel with the complete event history.
@@ -131,7 +131,8 @@ The visual variety and evolutionary mechanics are powered by a custom WebAssembl
     -   `src/components/Modal.tsx`: A generic modal component.
     -   `src/components/DataPanel.tsx`: The main UI for the slide-out panel containing challenges, analytics, and the Seed Bank, with a tabbed interface.
     -   `src/components/ChallengesPanel.tsx`: Renders the list of challenges and their progress.
-    -   `src/components/ChartsPanel.tsx`: Renders all the data visualization charts using data from the `analyticsStore`.
+    -   `src/components/ChartsPanel.tsx`: The main container for the analytics tab that renders the individual chart components.
+    -   `src/components/charts/`: A directory containing individual, specialized chart components (`PopulationChart`, `EnvironmentChart`, etc.), making the analytics section more modular.
     -   `src/components/Chart.tsx`: A reusable wrapper component for the `echarts-for-react` library.
     -   `src/components/SeedBankPanel.tsx`: Renders the champion flowers saved in the Seed Bank.
     -   `src/components/StatusPanel.tsx`: The main container in the header for status information, including the global search widget.

--- a/e2e/controllers/FlowerPanelController.ts
+++ b/e2e/controllers/FlowerPanelController.ts
@@ -39,9 +39,11 @@ export class FlowerPanelController {
             
             const selectionVisible = await this.actorSelectionPanel.isVisible({ timeout: 250 });
             if (selectionVisible) {
-                const actorButton = this.actorSelectionPanel.getByRole('button', { name: new RegExp(actorType, 'i') });
-                if (await actorButton.isVisible()) {
-                    await actorButton.click();
+                const actorButtons = this.actorSelectionPanel.getByRole('button', { name: new RegExp(actorType, 'i') });
+                // If there's at least one button matching the actor type, click the first one.
+                // This resolves strict mode violations when multiple actors of the same type are in one cell.
+                if (await actorButtons.count() > 0) {
+                    await actorButtons.first().click();
                     return true;
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evogarden",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "A dynamic garden simulation where flowers evolve under the pressure of insects and birds. Watch a Darwinian battlefield unfold as flowers, insects, and birds interact in a delicate ecosystem, with visual traits driven by NEAT Algorithm.",
   "private": true,
   "type": "module",

--- a/src/components/ChartsPanel.tsx
+++ b/src/components/ChartsPanel.tsx
@@ -1,230 +1,34 @@
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import { useAnalyticsStore } from '../stores/analyticsStore';
-import { Chart } from './Chart';
-import type { EChartsOption } from 'echarts';
-
-const baseChartOptions: EChartsOption = {
-    grid: { top: 120, left: '3%', right: '4%', bottom: '3%', containLabel: true },
-    tooltip: { trigger: 'axis' },
-    xAxis: { 
-        type: 'category',
-        axisLine: { lineStyle: { color: 'hsl(90, 50%, 70%)' } },
-        splitLine: { show: false },
-        axisLabel: { color: '#bbf7d0' },
-    },
-    yAxis: { 
-        type: 'value',
-        axisLine: { show: true, lineStyle: { color: 'hsl(90, 50%, 70%)' } },
-        splitLine: { 
-            lineStyle: { 
-                color: 'hsl(120, 10%, 45%)',
-                type: 'solid' 
-            } 
-        },
-        axisLabel: { color: '#bbf7d0' },
-    },
-    legend: { data: [] },
-    backgroundColor: 'transparent',
-    textStyle: {
-        fontFamily: 'sans-serif',
-        color: '#bbf7d0' // primary-light
-    }
-};
-
-const createLegendSelectHandler = (
-    setter: React.Dispatch<React.SetStateAction<Record<string, boolean>>>
-) => (params: { selected: Record<string, boolean> }) => {
-    setter(params.selected);
-};
-
+import { EnvironmentChart } from './charts/EnvironmentChart';
+import { PopulationChart } from './charts/PopulationChart';
+import { EventsChart } from './charts/EventsChart';
+import { FlowerTraitsChart } from './charts/FlowerTraitsChart';
+import { BaseEffectsChart } from './charts/BaseEffectsChart';
+import { PerformanceChart } from './charts/PerformanceChart';
 
 export const ChartsPanel: React.FC = () => {
     const history = useAnalyticsStore(state => state.history);
-    
-    // State to hold legend visibility for each chart
-    const [performanceLegend, setPerformanceLegend] = useState<Record<string, boolean>>({ 'Tick Time (Worker)': true, 'Render Time (UI)': true, 'Pending Requests': true });
-    const [populationLegend, setPopulationLegend] = useState<Record<string, boolean>>({ 'Flowers': true, 'Insects': true, 'Birds': true, 'Eagles': true, 'Herbicide Planes': true, 'Herbicide Smokes': true, 'Eggs': true, 'Corpses': true, 'Cockroaches': true });
-    const [eventsLegend, setEventsLegend] = useState<Record<string, boolean>>({ 'Reproductions': true, 'Insects Eaten': true, 'Eggs Laid': true, 'Insects Born': true, 'Eggs Eaten': true, 'Died of Old Age': true });
-    const [traitsLegend, setTraitsLegend] = useState<Record<string, boolean>>({ 'Avg Health': true, 'Max Health': true, 'Avg Stamina': true, 'Max Stamina': true, 'Avg Maturation': true, 'Avg Nutrient Efficiency': true, 'Max Toxicity': true });
-    const [effectsLegend, setEffectsLegend] = useState<Record<string, boolean>>({ 'Avg Vitality': true, 'Avg Agility': true, 'Avg Strength': true, 'Avg Intelligence': true, 'Avg Luck': true });
-    const [environmentLegend, setEnvironmentLegend] = useState<Record<string, boolean>>({ 'Temperature (°C)': true, 'Humidity (%)': true });
-
-    // Event handlers for legend changes
-    const handlePerformanceLegendChange = createLegendSelectHandler(setPerformanceLegend);
-    const handlePopulationLegendChange = createLegendSelectHandler(setPopulationLegend);
-    const handleEventsLegendChange = createLegendSelectHandler(setEventsLegend);
-    const handleTraitsLegendChange = createLegendSelectHandler(setTraitsLegend);
-    const handleEffectsLegendChange = createLegendSelectHandler(setEffectsLegend);
-    const handleEnvironmentLegendChange = createLegendSelectHandler(setEnvironmentLegend);
-
-    const environmentOption = useMemo<EChartsOption>(() => {
-        const ticks = history.map(h => h.tick);
-        return {
-            ...baseChartOptions,
-            title: { text: 'Environment', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
-            legend: { data: ['Temperature (°C)', 'Humidity (%)'], top: 35, textStyle: { color: '#bbf7d0' }, selected: environmentLegend },
-            xAxis: { ...baseChartOptions.xAxis, data: ticks },
-            yAxis: [
-                {
-                    ...(baseChartOptions.yAxis as object),
-                    type: 'value', name: '°C', position: 'left'
-                },
-                {
-                    ...(baseChartOptions.yAxis as object),
-                    type: 'value', name: '%', position: 'right', min: 0, max: 100,
-                    splitLine: { show: false },
-                }
-            ],
-            series: [
-                { name: 'Temperature (°C)', type: 'line', yAxisIndex: 0, data: history.map(h => h.currentTemperature?.toFixed(1)), color: '#f56565' },
-                { name: 'Humidity (%)', type: 'line', yAxisIndex: 1, data: history.map(h => ((h.currentHumidity ?? 0) * 100).toFixed(0)), color: '#4299e1' },
-            ],
-        };
-    }, [history, environmentLegend]);
-
-    const performanceOption = useMemo<EChartsOption>(() => {
-        const ticks = history.map(h => h.tick);
-        return {
-            ...baseChartOptions,
-            title: { text: 'Performance & Workload', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
-            legend: { data: ['Tick Time (Worker)', 'Render Time (UI)', 'Pending Requests'], top: 35, textStyle: { color: '#bbf7d0' }, selected: performanceLegend },
-            xAxis: { ...baseChartOptions.xAxis, data: ticks },
-            yAxis: [
-                {
-                    ...(baseChartOptions.yAxis as object),
-                    type: 'value',
-                    name: 'Milliseconds',
-                    position: 'left',
-                },
-                {
-                    ...(baseChartOptions.yAxis as object),
-                    type: 'value',
-                    name: 'Count',
-                    position: 'right',
-                    splitLine: { show: false },
-                },
-            ],
-            series: [
-                { name: 'Tick Time (Worker)', type: 'line', yAxisIndex: 0, data: history.map(h => h.tickTimeMs.toFixed(2)), color: '#38b2ac' },
-                { name: 'Render Time (UI)', type: 'line', yAxisIndex: 0, data: history.map(h => h.renderTimeMs.toFixed(2)), color: '#ed8936' },
-                { name: 'Pending Requests', type: 'line', yAxisIndex: 1, data: history.map(h => h.pendingFlowerRequests), color: '#ed64a6' },
-            ],
-        };
-    }, [history, performanceLegend]);
-
-    const populationOption = useMemo<EChartsOption>(() => {
-        const ticks = history.map(h => h.tick);
-        return {
-            ...baseChartOptions,
-            title: { text: 'Population Dynamics', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
-            legend: { data: ['Flowers', 'Insects', 'Birds', 'Eagles', 'Eggs', 'Herbicide Planes', 'Herbicide Smokes', 'Corpses', 'Cockroaches'], top: 35, textStyle: { color: '#bbf7d0' }, selected: populationLegend },
-            xAxis: { ...baseChartOptions.xAxis, data: ticks },
-            series: [
-                { name: 'Flowers', type: 'line', data: history.map(h => h.flowers), color: '#48bb78' },
-                { name: 'Insects', type: 'line', data: history.map(h => h.insects), color: '#4299e1' },
-                { name: 'Birds', type: 'line', data: history.map(h => h.birds), color: '#f56565' },
-                { name: 'Eagles', type: 'line', data: history.map(h => h.eagles), color: '#d69e2e' },
-                { name: 'Eggs', type: 'line', data: history.map(h => h.eggCount), color: '#a0aec0' },
-                { name: 'Herbicide Planes', type: 'line', data: history.map(h => h.herbicidePlanes || 0), color: '#cbd5e0' },
-                { name: 'Herbicide Smokes', type: 'line', data: history.map(h => h.herbicideSmokes || 0), color: '#718096' },
-                { name: 'Corpses', type: 'line', data: history.map(h => h.corpses || 0), color: '#a0aec0' },
-                { name: 'Cockroaches', type: 'line', data: history.map(h => h.cockroaches || 0), color: '#7a4a2a' },
-            ],
-        };
-    }, [history, populationLegend]);
-
-    const eventsOption = useMemo<EChartsOption>(() => {
-        const ticks = history.map(h => h.tick);
-        return {
-            ...baseChartOptions,
-            title: { text: 'Ecosystem Events', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
-            legend: { data: ['Reproductions', 'Insects Eaten', 'Eggs Laid', 'Insects Born', 'Eggs Eaten', 'Died of Old Age'], top: 35, textStyle: { color: '#bbf7d0' }, selected: eventsLegend },
-            xAxis: { ...baseChartOptions.xAxis, data: ticks },
-            series: [
-                { name: 'Reproductions', type: 'line', data: history.map(h => h.reproductions), color: '#9f7aea' },
-                { name: 'Insects Eaten', type: 'line', data: history.map(h => h.insectsEaten), color: '#ed8936' },
-                { name: 'Eggs Eaten', type: 'line', data: history.map(h => h.eggsEaten), color: '#a0aec0' },
-                { name: 'Eggs Laid', type: 'line', data: history.map(h => h.eggsLaid), color: '#ecc94b' },
-                { name: 'Insects Born', type: 'line', data: history.map(h => h.insectsBorn), color: '#63b3ed' },
-                { name: 'Died of Old Age', type: 'line', data: history.map(h => h.insectsDiedOfOldAge), color: '#f7fafc' },
-            ],
-        };
-    }, [history, eventsLegend]);
-
-    const flowerTraitsOption = useMemo<EChartsOption>(() => {
-        const ticks = history.map(h => h.tick);
-        return {
-            ...baseChartOptions,
-            title: { text: 'Flower Genetic Traits', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
-            legend: {
-                data: ['Avg Health', 'Max Health', 'Avg Stamina', 'Max Stamina', 'Avg Maturation', 'Avg Nutrient Efficiency', 'Max Toxicity'],
-                top: 35,
-                textStyle: { color: '#bbf7d0' },
-                selected: traitsLegend,
-            },
-            xAxis: { ...baseChartOptions.xAxis, data: ticks },
-            yAxis: [
-                {
-                    ...(baseChartOptions.yAxis as object),
-                    type: 'value', name: 'Health / Stamina / Ticks', position: 'left'
-                },
-                {
-                    ...(baseChartOptions.yAxis as object),
-                    type: 'value', name: 'Efficiency / Toxicity', position: 'right', min: 0,
-                    axisLabel: { formatter: (value: number) => value.toFixed(2), color: '#bbf7d0' },
-                    splitLine: { show: false }, // No grid lines for the right-side Y axis
-                }
-            ],
-            series: [
-                { name: 'Avg Health', type: 'line', yAxisIndex: 0, data: history.map(h => h.avgHealth.toFixed(2)), color: '#38b2ac' },
-                { name: 'Max Health', type: 'line', yAxisIndex: 0, data: history.map(h => h.maxHealth), color: '#63b3ed' },
-                { name: 'Avg Stamina', type: 'line', yAxisIndex: 0, data: history.map(h => h.avgStamina.toFixed(0)), color: '#4299e1' },
-                { name: 'Max Stamina', type: 'line', yAxisIndex: 0, data: history.map(h => h.maxStamina), color: '#3182ce' },
-                { name: 'Avg Maturation', type: 'line', yAxisIndex: 0, data: history.map(h => h.avgMaturationPeriod.toFixed(0)), color: '#d69e2e' },
-                { name: 'Avg Nutrient Efficiency', type: 'line', yAxisIndex: 1, data: history.map(h => h.avgNutrientEfficiency.toFixed(2)), color: '#38a169' },
-                { name: 'Max Toxicity', type: 'line', yAxisIndex: 1, data: history.map(h => h.maxToxicity.toFixed(2)), color: '#c05621' },
-            ],
-        };
-    }, [history, traitsLegend]);
-    
-    const baseEffectsOption = useMemo<EChartsOption>(() => {
-        const ticks = history.map(h => h.tick);
-        return {
-            ...baseChartOptions,
-            title: { text: 'Base Genetic Effects', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
-            legend: { data: ['Avg Vitality', 'Avg Agility', 'Avg Strength', 'Avg Intelligence', 'Avg Luck'], top: 35, textStyle: { color: '#bbf7d0' }, selected: effectsLegend },
-            xAxis: { ...baseChartOptions.xAxis, data: ticks },
-            yAxis: { ...baseChartOptions.yAxis, name: 'Effect Score' },
-            series: [
-                { name: 'Avg Vitality', type: 'line', data: history.map(h => h.avgVitality.toFixed(2)), color: '#e53e3e' },
-                { name: 'Avg Agility', type: 'line', data: history.map(h => h.avgAgility.toFixed(2)), color: '#38b2ac' },
-                { name: 'Avg Strength', type: 'line', data: history.map(h => h.avgStrength.toFixed(2)), color: '#ed8936' },
-                { name: 'Avg Intelligence', type: 'line', data: history.map(h => h.avgIntelligence.toFixed(2)), color: '#9f7aea' },
-                { name: 'Avg Luck', type: 'line', data: history.map(h => h.avgLuck.toFixed(2)), color: '#48bb78' },
-            ],
-        };
-    }, [history, effectsLegend]);
-
 
     return (
         <div className="p-4 space-y-4">
             <div className="bg-chart-background border-2 border-chart-border rounded-lg p-2">
-                <Chart option={environmentOption} onEvents={{ 'legendselectchanged': handleEnvironmentLegendChange }} />
+                <EnvironmentChart history={history} />
             </div>
             <div className="bg-chart-background border-2 border-chart-border rounded-lg p-2">
-                <Chart option={populationOption} onEvents={{ 'legendselectchanged': handlePopulationLegendChange }} />
+                <PopulationChart history={history} />
             </div>
              <div className="bg-chart-background border-2 border-chart-border rounded-lg p-2">
-                <Chart option={eventsOption} onEvents={{ 'legendselectchanged': handleEventsLegendChange }} />
+                <EventsChart history={history} />
             </div>
             <div className="bg-chart-background border-2 border-chart-border rounded-lg p-2">
-                <Chart option={flowerTraitsOption} onEvents={{ 'legendselectchanged': handleTraitsLegendChange }} />
+                <FlowerTraitsChart history={history} />
             </div>
             <div className="bg-chart-background border-2 border-chart-border rounded-lg p-2">
-                <Chart option={baseEffectsOption} onEvents={{ 'legendselectchanged': handleEffectsLegendChange }} />
+                <BaseEffectsChart history={history} />
             </div>
              <div className="bg-chart-background border-2 border-chart-border rounded-lg p-2">
-                <Chart option={performanceOption} onEvents={{ 'legendselectchanged': handlePerformanceLegendChange }} />
+                <PerformanceChart history={history} />
             </div>
         </div>
     );

--- a/src/components/charts/BaseEffectsChart.tsx
+++ b/src/components/charts/BaseEffectsChart.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo, useState } from 'react';
+import type { EChartsOption } from 'echarts';
+import type { AnalyticsDataPoint } from '../../types';
+import { Chart } from '../Chart';
+import { baseChartOptions, createLegendSelectHandler } from './chartOptions';
+
+interface BaseEffectsChartProps {
+    history: AnalyticsDataPoint[];
+}
+
+export const BaseEffectsChart: React.FC<BaseEffectsChartProps> = ({ history }) => {
+    const [effectsLegend, setEffectsLegend] = useState<Record<string, boolean>>({ 'Avg Vitality': true, 'Avg Agility': true, 'Avg Strength': true, 'Avg Intelligence': true, 'Avg Luck': true });
+    const handleEffectsLegendChange = createLegendSelectHandler(setEffectsLegend);
+
+    const baseEffectsOption = useMemo<EChartsOption>(() => {
+        const ticks = history.map(h => h.tick);
+        return {
+            ...baseChartOptions,
+            title: { text: 'Base Genetic Effects', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
+            legend: { data: ['Avg Vitality', 'Avg Agility', 'Avg Strength', 'Avg Intelligence', 'Avg Luck'], top: 35, textStyle: { color: '#bbf7d0' }, selected: effectsLegend },
+            xAxis: { ...baseChartOptions.xAxis, data: ticks },
+            yAxis: { ...baseChartOptions.yAxis, name: 'Effect Score' },
+            series: [
+                { name: 'Avg Vitality', type: 'line', data: history.map(h => h.avgVitality.toFixed(2)), color: '#e53e3e' },
+                { name: 'Avg Agility', type: 'line', data: history.map(h => h.avgAgility.toFixed(2)), color: '#38b2ac' },
+                { name: 'Avg Strength', type: 'line', data: history.map(h => h.avgStrength.toFixed(2)), color: '#ed8936' },
+                { name: 'Avg Intelligence', type: 'line', data: history.map(h => h.avgIntelligence.toFixed(2)), color: '#9f7aea' },
+                { name: 'Avg Luck', type: 'line', data: history.map(h => h.avgLuck.toFixed(2)), color: '#48bb78' },
+            ],
+        };
+    }, [history, effectsLegend]);
+    
+    return <Chart option={baseEffectsOption} onEvents={{ 'legendselectchanged': handleEffectsLegendChange }} />;
+};

--- a/src/components/charts/EnvironmentChart.tsx
+++ b/src/components/charts/EnvironmentChart.tsx
@@ -1,0 +1,41 @@
+import React, { useMemo, useState } from 'react';
+import type { EChartsOption } from 'echarts';
+import type { AnalyticsDataPoint } from '../../types';
+import { Chart } from '../Chart';
+import { baseChartOptions, createLegendSelectHandler } from './chartOptions';
+
+interface EnvironmentChartProps {
+    history: AnalyticsDataPoint[];
+}
+
+export const EnvironmentChart: React.FC<EnvironmentChartProps> = ({ history }) => {
+    const [environmentLegend, setEnvironmentLegend] = useState<Record<string, boolean>>({ 'Temperature (°C)': true, 'Humidity (%)': true });
+    const handleEnvironmentLegendChange = createLegendSelectHandler(setEnvironmentLegend);
+
+    const environmentOption = useMemo<EChartsOption>(() => {
+        const ticks = history.map(h => h.tick);
+        return {
+            ...baseChartOptions,
+            title: { text: 'Environment', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
+            legend: { data: ['Temperature (°C)', 'Humidity (%)'], top: 35, textStyle: { color: '#bbf7d0' }, selected: environmentLegend },
+            xAxis: { ...baseChartOptions.xAxis, data: ticks },
+            yAxis: [
+                {
+                    ...(baseChartOptions.yAxis as object),
+                    type: 'value', name: '°C', position: 'left'
+                },
+                {
+                    ...(baseChartOptions.yAxis as object),
+                    type: 'value', name: '%', position: 'right', min: 0, max: 100,
+                    splitLine: { show: false },
+                }
+            ],
+            series: [
+                { name: 'Temperature (°C)', type: 'line', yAxisIndex: 0, data: history.map(h => h.currentTemperature?.toFixed(1)), color: '#f56565' },
+                { name: 'Humidity (%)', type: 'line', yAxisIndex: 1, data: history.map(h => ((h.currentHumidity ?? 0) * 100).toFixed(0)), color: '#4299e1' },
+            ],
+        };
+    }, [history, environmentLegend]);
+    
+    return <Chart option={environmentOption} onEvents={{ 'legendselectchanged': handleEnvironmentLegendChange }} />;
+};

--- a/src/components/charts/EventsChart.tsx
+++ b/src/components/charts/EventsChart.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo, useState } from 'react';
+import type { EChartsOption } from 'echarts';
+import type { AnalyticsDataPoint } from '../../types';
+import { Chart } from '../Chart';
+import { baseChartOptions, createLegendSelectHandler } from './chartOptions';
+
+interface EventsChartProps {
+    history: AnalyticsDataPoint[];
+}
+
+export const EventsChart: React.FC<EventsChartProps> = ({ history }) => {
+    const [eventsLegend, setEventsLegend] = useState<Record<string, boolean>>({ 'Reproductions': true, 'Insects Eaten': true, 'Eggs Laid': true, 'Insects Born': true, 'Eggs Eaten': true, 'Died of Old Age': true });
+    const handleEventsLegendChange = createLegendSelectHandler(setEventsLegend);
+    
+    const eventsOption = useMemo<EChartsOption>(() => {
+        const ticks = history.map(h => h.tick);
+        return {
+            ...baseChartOptions,
+            title: { text: 'Ecosystem Events', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
+            legend: { data: ['Reproductions', 'Insects Eaten', 'Eggs Laid', 'Insects Born', 'Eggs Eaten', 'Died of Old Age'], top: 35, textStyle: { color: '#bbf7d0' }, selected: eventsLegend },
+            xAxis: { ...baseChartOptions.xAxis, data: ticks },
+            series: [
+                { name: 'Reproductions', type: 'line', data: history.map(h => h.reproductions), color: '#9f7aea' },
+                { name: 'Insects Eaten', type: 'line', data: history.map(h => h.insectsEaten), color: '#ed8936' },
+                { name: 'Eggs Eaten', type: 'line', data: history.map(h => h.eggsEaten), color: '#a0aec0' },
+                { name: 'Eggs Laid', type: 'line', data: history.map(h => h.eggsLaid), color: '#ecc94b' },
+                { name: 'Insects Born', type: 'line', data: history.map(h => h.insectsBorn), color: '#63b3ed' },
+                { name: 'Died of Old Age', type: 'line', data: history.map(h => h.insectsDiedOfOldAge), color: '#f7fafc' },
+            ],
+        };
+    }, [history, eventsLegend]);
+    
+    return <Chart option={eventsOption} onEvents={{ 'legendselectchanged': handleEventsLegendChange }} />;
+};

--- a/src/components/charts/FlowerTraitsChart.tsx
+++ b/src/components/charts/FlowerTraitsChart.tsx
@@ -1,0 +1,52 @@
+import React, { useMemo, useState } from 'react';
+import type { EChartsOption } from 'echarts';
+import type { AnalyticsDataPoint } from '../../types';
+import { Chart } from '../Chart';
+import { baseChartOptions, createLegendSelectHandler } from './chartOptions';
+
+interface FlowerTraitsChartProps {
+    history: AnalyticsDataPoint[];
+}
+
+export const FlowerTraitsChart: React.FC<FlowerTraitsChartProps> = ({ history }) => {
+    const [traitsLegend, setTraitsLegend] = useState<Record<string, boolean>>({ 'Avg Health': true, 'Max Health': true, 'Avg Stamina': true, 'Max Stamina': true, 'Avg Maturation': true, 'Avg Nutrient Efficiency': true, 'Max Toxicity': true });
+    const handleTraitsLegendChange = createLegendSelectHandler(setTraitsLegend);
+
+    const flowerTraitsOption = useMemo<EChartsOption>(() => {
+        const ticks = history.map(h => h.tick);
+        return {
+            ...baseChartOptions,
+            title: { text: 'Flower Genetic Traits', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
+            legend: {
+                data: ['Avg Health', 'Max Health', 'Avg Stamina', 'Max Stamina', 'Avg Maturation', 'Avg Nutrient Efficiency', 'Max Toxicity'],
+                top: 35,
+                textStyle: { color: '#bbf7d0' },
+                selected: traitsLegend,
+            },
+            xAxis: { ...baseChartOptions.xAxis, data: ticks },
+            yAxis: [
+                {
+                    ...(baseChartOptions.yAxis as object),
+                    type: 'value', name: 'Health / Stamina / Ticks', position: 'left'
+                },
+                {
+                    ...(baseChartOptions.yAxis as object),
+                    type: 'value', name: 'Efficiency / Toxicity', position: 'right', min: 0,
+                    axisLabel: { formatter: (value: number) => value.toFixed(2), color: '#bbf7d0' },
+                    splitLine: { show: false }, // No grid lines for the right-side Y axis
+                }
+            ],
+            series: [
+                { name: 'Avg Health', type: 'line', yAxisIndex: 0, data: history.map(h => h.avgHealth.toFixed(2)), color: '#38b2ac' },
+                { name: 'Max Health', type: 'line', yAxisIndex: 0, data: history.map(h => h.maxHealth), color: '#63b3ed' },
+                { name: 'Avg Stamina', type: 'line', yAxisIndex: 0, data: history.map(h => h.avgStamina.toFixed(0)), color: '#4299e1' },
+                { name: 'Max Stamina', type: 'line', yAxisIndex: 0, data: history.map(h => h.maxStamina), color: '#3182ce' },
+                { name: 'Avg Maturation', type: 'line', yAxisIndex: 0, data: history.map(h => h.avgMaturationPeriod.toFixed(0)), color: '#d69e2e' },
+                { name: 'Avg Nutrient Efficiency', type: 'line', yAxisIndex: 1, data: history.map(h => h.avgNutrientEfficiency.toFixed(2)), color: '#38a169' },
+                { name: 'Max Toxicity', type: 'line', yAxisIndex: 1, data: history.map(h => h.maxToxicity.toFixed(2)), color: '#c05621' },
+            ],
+        };
+    }, [history, traitsLegend]);
+
+    return <Chart option={flowerTraitsOption} onEvents={{ 'legendselectchanged': handleTraitsLegendChange }} />;
+};

--- a/src/components/charts/PerformanceChart.tsx
+++ b/src/components/charts/PerformanceChart.tsx
@@ -1,0 +1,46 @@
+import React, { useMemo, useState } from 'react';
+import type { EChartsOption } from 'echarts';
+import type { AnalyticsDataPoint } from '../../types';
+import { Chart } from '../Chart';
+import { baseChartOptions, createLegendSelectHandler } from './chartOptions';
+
+interface PerformanceChartProps {
+    history: AnalyticsDataPoint[];
+}
+
+export const PerformanceChart: React.FC<PerformanceChartProps> = ({ history }) => {
+    const [performanceLegend, setPerformanceLegend] = useState<Record<string, boolean>>({ 'Tick Time (Worker)': true, 'Render Time (UI)': true, 'Pending Requests': true });
+    const handlePerformanceLegendChange = createLegendSelectHandler(setPerformanceLegend);
+
+    const performanceOption = useMemo<EChartsOption>(() => {
+        const ticks = history.map(h => h.tick);
+        return {
+            ...baseChartOptions,
+            title: { text: 'Performance & Workload', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
+            legend: { data: ['Tick Time (Worker)', 'Render Time (UI)', 'Pending Requests'], top: 35, textStyle: { color: '#bbf7d0' }, selected: performanceLegend },
+            xAxis: { ...baseChartOptions.xAxis, data: ticks },
+            yAxis: [
+                {
+                    ...(baseChartOptions.yAxis as object),
+                    type: 'value',
+                    name: 'Milliseconds',
+                    position: 'left',
+                },
+                {
+                    ...(baseChartOptions.yAxis as object),
+                    type: 'value',
+                    name: 'Count',
+                    position: 'right',
+                    splitLine: { show: false },
+                },
+            ],
+            series: [
+                { name: 'Tick Time (Worker)', type: 'line', yAxisIndex: 0, data: history.map(h => h.tickTimeMs.toFixed(2)), color: '#38b2ac' },
+                { name: 'Render Time (UI)', type: 'line', yAxisIndex: 0, data: history.map(h => h.renderTimeMs.toFixed(2)), color: '#ed8936' },
+                { name: 'Pending Requests', type: 'line', yAxisIndex: 1, data: history.map(h => h.pendingFlowerRequests), color: '#ed64a6' },
+            ],
+        };
+    }, [history, performanceLegend]);
+
+    return <Chart option={performanceOption} onEvents={{ 'legendselectchanged': handlePerformanceLegendChange }} />;
+};

--- a/src/components/charts/PopulationChart.tsx
+++ b/src/components/charts/PopulationChart.tsx
@@ -1,0 +1,56 @@
+import React, { useMemo, useState } from 'react';
+import type { EChartsOption } from 'echarts';
+import type { AnalyticsDataPoint } from '../../types';
+import { Chart } from '../Chart';
+import { baseChartOptions, createLegendSelectHandler } from './chartOptions';
+
+interface PopulationChartProps {
+    history: AnalyticsDataPoint[];
+}
+
+export const PopulationChart: React.FC<PopulationChartProps> = ({ history }) => {
+    const [populationLegend, setPopulationLegend] = useState<Record<string, boolean>>({ 
+        'Total Flowers': true, 
+        'Healing Flowers': true,
+        'Toxic Flowers': true,
+        'Insects': true, 
+        'Birds': true, 
+        'Eagles': true, 
+        'Eggs': true, 
+        'Herbicide Planes': true, 
+        'Herbicide Smokes': true, 
+        'Corpses': true, 
+        'Cockroaches': true,
+    });
+    const handlePopulationLegendChange = createLegendSelectHandler(setPopulationLegend);
+
+    const populationOption = useMemo<EChartsOption>(() => {
+        const ticks = history.map(h => h.tick);
+        return {
+            ...baseChartOptions,
+            title: { text: 'Population Dynamics', left: 'center', textStyle: { color: '#bbf7d0', fontWeight: 'bold' }, top: 0 },
+            legend: { 
+                data: ['Flowers', 'Insects', 'Birds', 'Eagles', 'Eggs', 'Herbicide Planes', 'Herbicide Smokes', 'Corpses', 'Cockroaches', 'Healing Flowers', 'Toxic Flowers'], 
+                top: 35, 
+                textStyle: { color: '#bbf7d0' }, 
+                selected: populationLegend 
+            },
+            xAxis: { ...baseChartOptions.xAxis, data: ticks },
+            series: [
+                { name: 'Total Flowers', type: 'line', data: history.map(h => h.flowers), color: '#48bb78' },
+                { name: 'Healing Flowers', type: 'line', data: history.map(h => h.healingFlowerCount || 0), color: '#38a169', lineStyle: { type: 'dashed' } },
+                { name: 'Toxic Flowers', type: 'line', data: history.map(h => h.toxicFlowerCount || 0), color: '#c05621', lineStyle: { type: 'dashed' } },
+                { name: 'Insects', type: 'line', data: history.map(h => h.insects), color: '#4299e1' },
+                { name: 'Birds', type: 'line', data: history.map(h => h.birds), color: '#f56565' },
+                { name: 'Eagles', type: 'line', data: history.map(h => h.eagles), color: '#d69e2e' },
+                { name: 'Eggs', type: 'line', data: history.map(h => h.eggCount), color: '#a0aec0' },
+                { name: 'Herbicide Planes', type: 'line', data: history.map(h => h.herbicidePlanes || 0), color: '#cbd5e0' },
+                { name: 'Herbicide Smokes', type: 'line', data: history.map(h => h.herbicideSmokes || 0), color: '#718096' },
+                { name: 'Corpses', type: 'line', data: history.map(h => h.corpses || 0), color: '#a0aec0' },
+                { name: 'Cockroaches', type: 'line', data: history.map(h => h.cockroaches || 0), color: '#7a4a2a' },
+            ],
+        };
+    }, [history, populationLegend]);
+
+    return <Chart option={populationOption} onEvents={{ 'legendselectchanged': handlePopulationLegendChange }} />;
+};

--- a/src/components/charts/chartOptions.ts
+++ b/src/components/charts/chartOptions.ts
@@ -1,0 +1,36 @@
+import type { EChartsOption } from 'echarts';
+import React from 'react';
+
+export const baseChartOptions: EChartsOption = {
+    grid: { top: 120, left: '3%', right: '4%', bottom: '3%', containLabel: true },
+    tooltip: { trigger: 'axis' },
+    xAxis: { 
+        type: 'category',
+        axisLine: { lineStyle: { color: 'hsl(90, 50%, 70%)' } },
+        splitLine: { show: false },
+        axisLabel: { color: '#bbf7d0' },
+    },
+    yAxis: { 
+        type: 'value',
+        axisLine: { show: true, lineStyle: { color: 'hsl(90, 50%, 70%)' } },
+        splitLine: { 
+            lineStyle: { 
+                color: 'hsl(120, 10%, 45%)',
+                type: 'solid' 
+            } 
+        },
+        axisLabel: { color: '#bbf7d0' },
+    },
+    legend: { data: [] },
+    backgroundColor: 'transparent',
+    textStyle: {
+        fontFamily: 'sans-serif',
+        color: '#bbf7d0' // primary-light
+    }
+};
+
+export const createLegendSelectHandler = (
+    setter: React.Dispatch<React.SetStateAction<Record<string, boolean>>>
+) => (params: { selected: Record<string, boolean> }) => {
+    setter(params.selected);
+};

--- a/src/lib/simulationEngine.ts
+++ b/src/lib/simulationEngine.ts
@@ -14,7 +14,7 @@ import { db } from '../services/db';
 import { PopulationManager } from './populationManager';
 import { AsyncFlowerFactory } from './asyncFlowerFactory';
 import * as ecosystemManager from './ecosystemManager';
-import { DEFAULT_SIM_PARAMS, INSECT_DATA } from '../constants';
+import { DEFAULT_SIM_PARAMS, INSECT_DATA, TOXIC_FLOWER_THRESHOLD } from '../constants';
 import { Quadtree } from './Quadtree';
 import { updateEnvironment } from './environmentManager';
 
@@ -264,6 +264,8 @@ export class SimulationEngine {
         let totalHealth = 0, totalStamina = 0, totalNutrientEfficiency = 0, totalMaturationPeriod = 0;
         let maxHealthSoFar = 0, maxStaminaSoFar = 0, maxToxicitySoFar = 0;
         let totalVitality = 0, totalAgility = 0, totalStrength = 0, totalIntelligence = 0, totalLuck = 0;
+        let healingFlowerCount = 0;
+        let toxicFlowerCount = 0;
 
         for (const actor of nextActorState.values()) {
             if (actor.type === 'flower') {
@@ -274,6 +276,11 @@ export class SimulationEngine {
                 maxToxicitySoFar = Math.max(maxToxicitySoFar, f.toxicityRate);
                 totalVitality += f.effects.vitality; totalAgility += f.effects.agility; totalStrength += f.effects.strength;
                 totalIntelligence += f.effects.intelligence; totalLuck += f.effects.luck;
+                if (f.toxicityRate < 0) {
+                    healingFlowerCount++;
+                } else if (f.toxicityRate > TOXIC_FLOWER_THRESHOLD) {
+                    toxicFlowerCount++;
+                }
             } else if (actor.type === 'flowerSeed') {
                 seedCount++;
             } else if (actor.type === 'insect') {
@@ -327,6 +334,8 @@ export class SimulationEngine {
             season: this.environmentState.season,
             weatherEvent: this.environmentState.currentWeatherEvent.type,
             pendingFlowerRequests: this.asyncFlowerFactory.getPendingRequestCount(),
+            healingFlowerCount,
+            toxicFlowerCount,
         };
     }
     

--- a/src/stores/analyticsStore.ts
+++ b/src/stores/analyticsStore.ts
@@ -50,6 +50,8 @@ export const useAnalyticsStore = create<AnalyticsState>()(
                     season: summary.season,
                     weatherEvent: summary.weatherEvent,
                     pendingFlowerRequests: summary.pendingFlowerRequests,
+                    healingFlowerCount: summary.healingFlowerCount,
+                    toxicFlowerCount: summary.toxicFlowerCount,
                 };
                 
                 const newHistory = [...get().history, newPoint];

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -116,6 +116,8 @@ export interface TickSummary {
     season: Season;
     weatherEvent: WeatherEventType;
     pendingFlowerRequests: number;
+    healingFlowerCount: number;
+    toxicFlowerCount: number;
 }
 
 export interface FlowerCreationRequest {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -52,10 +52,10 @@ export interface AnalyticsDataPoint {
     cockroaches: number;
     reproductions: number;
     insectsEaten: number;
-    eggsEaten: number;
-    insectsDiedOfOldAge: number;
     eggsLaid: number;
     insectsBorn: number;
+    eggsEaten: number;
+    insectsDiedOfOldAge: number;
     totalBirdsHunted: number;
     totalHerbicidePlanesSpawned: number;
     nutrientCount: number;
@@ -79,6 +79,8 @@ export interface AnalyticsDataPoint {
     season?: Season;
     weatherEvent?: WeatherEventType;
     pendingFlowerRequests: number;
+    healingFlowerCount: number;
+    toxicFlowerCount: number;
 }
 
 export interface AnalyticsState {


### PR DESCRIPTION
This commit introduces a major refactoring of the analytics UI for improved maintainability and adds new data points for tracking specialized flower types.

The monolithic `ChartsPanel` component, which managed the state and configuration for all six charts, has been decomposed. Each chart is now its own modular component within a new `src/components/charts/` directory, simplifying future development and reducing complexity. A common `chartOptions.ts` utility has been created to share base configurations and reduce code duplication.

Key Changes:

-   **Refactor**: Extracted `PopulationChart`, `EnvironmentChart`, `EventsChart`, `FlowerTraitsChart`, `BaseEffectsChart`, and `PerformanceChart` into individual components.
-   **Feature**: The simulation engine now tracks and reports the count of "healing" (negative toxicity) and "toxic" flowers. This data is now visualized as new series on the Population Dynamics chart.
-   **Fix(e2e)**: Resolved a Playwright strict mode violation in the `FlowerPanelController` by updating the actor selection logic to click the `.first()` matching element, making the test more robust when multiple actors occupy the same cell.
-   **Docs**: Updated the README and Planning documents to reflect the new analytics capabilities and refactored component structure.