### PR TITLE
feat(insect-ids): Introduce human-readable short IDs and descriptive actor IDs

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -228,7 +228,20 @@ test.describe('Global Search', () => {
         await search.clickTrackButton();
 
         // 8. Verify it's in tracking mode
-        await expect(page.getByText(`Tracking: ${insectId.substring(7, 12)}`)).toBeVisible();
+        const getShortId = (id: string): string => {
+            const parts = id.split('-');
+            if (parts.length > 2) {
+                const dataParts = parts.slice(1, parts.length - 1);
+                const timestamp = parts[parts.length - 1];
+                if (!isNaN(parseInt(timestamp, 10))) {
+                    return `${dataParts.join('-')}-${timestamp.slice(-2)}`;
+                }
+            }
+            return id.slice(-5);
+        };
+        const trackingInput = page.getByLabel('Currently tracking actor');
+        await expect(trackingInput).toBeVisible();
+        await expect(trackingInput).toHaveValue(`Tracking: ${getShortId(insectId)}`);
     });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evogarden",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "A dynamic garden simulation where flowers evolve under the pressure of insects and birds. Watch a Darwinian battlefield unfold as flowers, insects, and birds interact in a delicate ecosystem, with visual traits driven by NEAT Algorithm.",
   "private": true,
   "type": "module",

--- a/src/components/EggDetailsPanel.tsx
+++ b/src/components/EggDetailsPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Egg } from '../types';
 import { XIcon, SearchIcon } from './icons';
 import { INSECT_DATA } from '../constants';
+import { getShortId } from '../utils';
 
 interface EggDetailsPanelProps {
     egg: Egg | null;
@@ -22,7 +23,7 @@ export const EggDetailsPanel: React.FC<EggDetailsPanelProps> = ({ egg, onClose, 
             <header className="flex items-center justify-between p-1 pl-4 bg-background text-primary-light rounded-t-[5px] min-h-[48px]">
                  <h2 className="font-bold text-lg truncate">
                     {isTrackingThisEgg ? 'Tracking: ' : 'Egg Details'}
-                    {isTrackingThisEgg && <span className="font-mono text-accent-yellow">{egg.id.substring(7, 12)}</span>}
+                    {isTrackingThisEgg && <span className="font-mono text-accent-yellow">{getShortId(egg.id)}</span>}
                 </h2>
                 <div className="flex items-center gap-2">
                     {isTrackingThisEgg && (

--- a/src/components/FlowerDetailsPanel.tsx
+++ b/src/components/FlowerDetailsPanel.tsx
@@ -5,6 +5,7 @@ import { flowerService } from '../services/flowerService';
 import { Modal } from './Modal';
 import { Flower3DViewer } from './Flower3DViewer';
 import { TOXIC_FLOWER_THRESHOLD } from '../constants';
+import { getShortId } from '../utils';
 
 interface FlowerDetailsPanelProps {
     flower: Flower | null;
@@ -90,7 +91,7 @@ export const FlowerDetailsPanel: React.FC<FlowerDetailsPanelProps> = ({ flower, 
             <header className="flex items-center justify-between p-1 pl-4 bg-background text-primary-light rounded-t-[5px] min-h-[48px]">
                 <h2 className="font-bold text-lg truncate">
                     {isTrackingThisFlower ? 'Tracking: ' : 'Flower Details'}
-                    {isTrackingThisFlower && <span className="font-mono text-accent-yellow">{flower.id.substring(7, 12)}</span>}
+                    {isTrackingThisFlower && <span className="font-mono text-accent-yellow">{getShortId(flower.id)}</span>}
                 </h2>
                 <div className="flex items-center gap-2">
                     {isTrackingThisFlower && (
@@ -236,7 +237,7 @@ export const FlowerDetailsPanel: React.FC<FlowerDetailsPanelProps> = ({ flower, 
             {flower && <Modal
                 isOpen={is3DViewerOpen}
                 onClose={handleClose3DViewer}
-                title={`3D Model for Flower #${flower.id.substring(7, 12)}`}
+                title={`3D Model for Flower #${getShortId(flower.id)}`}
             >
                 {isLoading3D || !gltfString ? (
                     <div className="flex items-center justify-center h-full">

--- a/src/components/GenericActorDetailsPanel.tsx
+++ b/src/components/GenericActorDetailsPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { CellContent, Bird, Eagle, Nutrient, Corpse, Cocoon, SlimeTrail, Hive, TerritoryMark, AntColony, PheromoneTrail } from '../types';
 import { XIcon, SearchIcon } from './icons';
 import { GenomeVisualizer } from './GenomeVisualizer';
+import { getShortId } from '../utils';
 
 interface GenericActorDetailsPanelProps {
     actor: CellContent | null;
@@ -182,7 +183,7 @@ export const GenericActorDetailsPanel: React.FC<GenericActorDetailsPanelProps> =
             <header className="flex items-center justify-between p-1 pl-4 bg-background text-primary-light rounded-t-[5px] min-h-[48px]">
                 <h2 className="font-bold text-lg truncate">
                     {isTrackingThisActor ? 'Tracking: ' : title}
-                    {isTrackingThisActor && <span className="font-mono text-accent-yellow">{actor.id.substring(7, 12)}</span>}
+                    {isTrackingThisActor && <span className="font-mono text-accent-yellow">{getShortId(actor.id)}</span>}
                 </h2>
                 <div className="flex items-center gap-2">
                     {isTrackingThisActor && (

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { Trie } from '../lib/Trie';
 import type { CellContent } from '../types';
 import { SearchIcon, XIcon } from './icons';
+import { getShortId } from '../utils';
 
 interface GlobalSearchProps {
     actors: Map<string, CellContent>;
@@ -100,7 +101,7 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({ actors, onTrackActor
              <div className="relative font-mono flex items-center">
                 <input
                     type="text"
-                    value={`Tracking: ${trackedActorId.substring(7, 12)}`}
+                    value={`Tracking: ${getShortId(trackedActorId)}`}
                     disabled
                     className="bg-background text-xs rounded-l-md pl-2 pr-2 py-1 w-48 text-accent-yellow shadow-[inset_0_1px_1px_0_#000]"
                     aria-label="Currently tracking actor"

--- a/src/components/InsectDetailsPanel.tsx
+++ b/src/components/InsectDetailsPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Insect, Cockroach } from '../types';
 import { XIcon, SearchIcon } from './icons';
 import { INSECT_DATA, CATERPILLAR_EAT_AMOUNT_FOR_COCOON } from '../constants';
-import { ACTOR_NAMES } from '../utils';
+import { ACTOR_NAMES, getShortId } from '../utils';
 import { GenomeVisualizer } from './GenomeVisualizer';
 
 interface InsectDetailsPanelProps {
@@ -40,7 +40,7 @@ export const InsectDetailsPanel: React.FC<InsectDetailsPanelProps> = ({ insect, 
             <header className="flex items-center justify-between p-1 pl-4 bg-background text-primary-light rounded-t-[5px] min-h-[48px]">
                  <h2 className="font-bold text-lg truncate">
                     {isTrackingThisInsect ? 'Tracking: ' : `${actorName} Details`}
-                    {isTrackingThisInsect && <span className="font-mono text-accent-yellow">{insect.id.substring(7, 12)}</span>}
+                    {isTrackingThisInsect && <span className="font-mono text-accent-yellow">{getShortId(insect.id)}</span>}
                 </h2>
                 <div className="flex items-center gap-2">
                     {isTrackingThisInsect && (
@@ -103,7 +103,7 @@ export const InsectDetailsPanel: React.FC<InsectDetailsPanelProps> = ({ insect, 
                  <div className="text-sm space-y-1 text-secondary border-t border-border/50 pt-2">
                     <h3 className="text-base font-semibold text-primary-light/80 mb-1">Status</h3>
                     {insect.type === 'insect' && (insect as Insect).pollen && (
-                        <p><strong>Carrying Pollen:</strong> Yes (from #{(insect as Insect).pollen!.sourceFlowerId.substring(7,12)})</p>
+                        <p><strong>Carrying Pollen:</strong> Yes (from #{getShortId((insect as Insect).pollen!.sourceFlowerId)})</p>
                     )}
                     {insect.type === 'insect' && !(insect as Insect).pollen && (
                         <p><strong>Carrying Pollen:</strong> No</p>

--- a/src/hooks/useActorTracker.ts
+++ b/src/hooks/useActorTracker.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { eventService } from '../services/eventService';
 import type { CellContent } from '../types';
+import { getShortId } from '../utils';
 
 interface UseActorTrackerProps {
     actors: Map<string, CellContent>;
@@ -26,7 +27,7 @@ export const useActorTracker = ({ actors, isRunning, setIsRunning, setSelectedAc
             wasRunningBeforeTrackingRef.current = isRunning;
             setTrackedActorId(actorToTrack.id);
             setIsRunning(true);
-            eventService.dispatch({ message: `Tracking ${actorType} #${actorToTrack.id.substring(7, 12)}`, type: 'info', importance: 'high' });
+            eventService.dispatch({ message: `Tracking ${actorType} #${getShortId(actorToTrack.id)}`, type: 'info', importance: 'high' });
         } else {
             eventService.dispatch({ message: `${actorType} ID containing "${id}" not found.`, type: 'error', importance: 'high' });
         }
@@ -36,7 +37,7 @@ export const useActorTracker = ({ actors, isRunning, setIsRunning, setSelectedAc
         if (trackedActorId) {
             const trackedActor = actors.get(trackedActorId);
             const actorType = trackedActor ? trackedActor.type : 'actor';
-            eventService.dispatch({ message: `Stopped tracking ${actorType} #${trackedActorId.substring(7, 12)}.`, type: 'info', importance: 'high' });
+            eventService.dispatch({ message: `Stopped tracking ${actorType} #${getShortId(trackedActorId)}.`, type: 'info', importance: 'high' });
         }
         setTrackedActorId(null);
         setSelectedActor(null);

--- a/src/lib/behaviors/antColonyBehavior.ts
+++ b/src/lib/behaviors/antColonyBehavior.ts
@@ -12,7 +12,7 @@ interface AntColonyContext {
 
 function createAntFromColony(colony: AntColony, position: {x: number, y: number}, params: SimulationParams): Insect {
     const baseStats = INSECT_DATA.get('🐜')!;
-    const newAntId = `insect-${position.x}-${position.y}-${Date.now()}`;
+    const newAntId = `insect-ant-${position.x}-${position.y}-${Date.now()}`;
     
     // Inherit from colony, with mutation
     const newGenome = [...colony.genome];

--- a/src/lib/behaviors/eggBehavior.ts
+++ b/src/lib/behaviors/eggBehavior.ts
@@ -1,5 +1,6 @@
 import type { Egg, CellContent, Insect, AppEvent, SimulationParams } from '../../types';
 import { INSECT_DATA } from '../../constants';
+import { ACTOR_NAMES } from '../../utils';
 
 interface EggContext {
     nextActorState: Map<string, CellContent>;
@@ -21,7 +22,8 @@ export const processEggTick = (egg: Egg, context: EggContext) => {
             return;
         }
 
-        const newInsectId = `insect-${egg.x}-${egg.y}-${Date.now()}`;
+        const typeName = (ACTOR_NAMES[egg.insectEmoji] || 'insect').toLowerCase();
+        const newInsectId = `insect-${typeName}-${egg.x}-${egg.y}-${Date.now()}`;
         const newInsect: Insect = {
             id: newInsectId,
             type: 'insect',

--- a/src/lib/behaviors/hiveBehavior.ts
+++ b/src/lib/behaviors/hiveBehavior.ts
@@ -12,7 +12,7 @@ interface HiveContext {
 
 function createBeeFromHive(hive: Hive, position: {x: number, y: number}, params: SimulationParams): Insect {
     const baseStats = INSECT_DATA.get('🐝')!;
-    const newBeeId = `insect-${position.x}-${position.y}-${Date.now()}`;
+    const newBeeId = `insect-honeybee-${position.x}-${position.y}-${Date.now()}`;
     
     // Inherit from hive, with mutation
     const newGenome = [...hive.genome];

--- a/src/lib/populationManager.ts
+++ b/src/lib/populationManager.ts
@@ -108,7 +108,7 @@ export class PopulationManager {
         if (corpseTrend === 'growing' && this.cockroachSpawnCooldown === 0) {
             const spot = findCellForStationaryActor(grid, this.params, 'cockroach');
             if (spot) {
-                const cockroachId = `cockroach-dyn-${Date.now()}`;
+                const cockroachId = `insect-cockroach-${spot.x}-${spot.y}-${Date.now()}`;
                 const baseStats = INSECT_DATA.get('🪳')!;
                 const cockroachGenome = Array(INSECT_GENOME_LENGTH).fill(0.1); // Mildly dislike everything else
                 cockroachGenome[FLOWER_STAT_INDICES.HEALTH] = -2.0; // Strongly dislike healthy flowers

--- a/src/lib/simulationInitializer.ts
+++ b/src/lib/simulationInitializer.ts
@@ -1,5 +1,5 @@
 import type { SimulationParams, CellContent, Flower, FEService, FlowerGenomeStats, Insect, Hive, AntColony } from '../types';
-import { getInsectEmoji, generateRandomInsectGenome } from '../utils';
+import { getInsectEmoji, generateRandomInsectGenome, ACTOR_NAMES } from '../utils';
 import { INSECT_DATA } from '../constants';
 
 // Fallback values
@@ -60,6 +60,8 @@ export const createInitialMobileActors = (params: SimulationParams): CellContent
         const baseStats = INSECT_DATA.get(emoji);
         
         if (baseStats) {
+            const typeName = (ACTOR_NAMES[emoji] || 'insect').toLowerCase();
+            const id = `insect-${typeName}-${-1}-${-1}-${Date.now() + i}`;
             const newInsect: Insect = { 
                 id, type: 'insect', x: -1, y: -1, 
                 pollen: null, emoji, 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,3 +73,25 @@ export const getActorName = (actor: CellContent): string => {
         default: return 'Unknown Entity';
     }
 };
+
+/**
+ * Creates a shortened, human-readable ID from a full actor ID.
+ * @param id The full actor ID string.
+ * @returns A shortened ID string.
+ */
+export const getShortId = (id: string): string => {
+    const parts = id.split('-');
+    // Handles formats like:
+    // insect-{type}-{x}-{y}-{timestamp} -> {type}-{x}-{y}-{ts}
+    // flower-{x}-{y}-{timestamp} -> {x}-{y}-{ts}
+    if (parts.length > 2) {
+        const dataParts = parts.slice(1, parts.length - 1);
+        const timestamp = parts[parts.length - 1];
+        // Ensure timestamp is a number before slicing
+        if (!isNaN(parseInt(timestamp, 10))) {
+            return `${dataParts.join('-')}-${timestamp.slice(-2)}`;
+        }
+    }
+    // Fallback for other ID formats
+    return id.slice(-5);
+};


### PR DESCRIPTION
This commit refactors actor ID generation and display to be more descriptive and user-friendly.

Key changes:
- A new `getShortId` utility is introduced to create a shortened, human-readable ID (e.g., `ant-10-25-99`) from a full actor ID.
- All UI components (Details Panels, Global Search, notifications) now use `getShortId` for a consistent and more informative display when tracking actors.
- The underlying actor ID generation for insects has been made more descriptive, changing from `insect-{coords}-{timestamp}` to `insect-{type}-{coords}-{timestamp}`.
- End-to-end tests have been updated to validate the new ID format in the UI.
- The package version has been bumped to `2.17.0`.