### PR TITLE
feat(simulation-speed): Implement live parameter updates and speed control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evogarden",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "A dynamic garden simulation where flowers evolve under the pressure of insects and birds. Watch a Darwinian battlefield unfold as flowers, insects, and birds interact in a delicate ecosystem, with visual traits driven by NEAT Algorithm.",
   "private": true,
   "type": "module",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,7 +93,7 @@ export default function App(): React.ReactNode {
   }, [params]);
 
 
-  const { actors, isRunning, setIsRunning, workerRef, resetWithNewParams, isWorkerInitialized, latestSummaryRef, workerError, latestSummary } = useSimulation({ setIsLoading });
+  const { actors, isRunning, setIsRunning, workerRef, resetWithNewParams, updateLiveParams, isWorkerInitialized, latestSummaryRef, workerError, latestSummary } = useSimulation({ setIsLoading });
   const { trackedActorId, handleTrackActor, handleStopTracking } = useActorTracker({ actors, isRunning, setIsRunning, setSelectedActor, selectedActor });
 
   useEffect(() => {
@@ -180,17 +180,23 @@ export default function App(): React.ReactNode {
       }
   }, [latestSummaryRef]);
 
-  const handleParamsChange = (newParams: SimulationParams) => {
-    setLoadingMessage('Resetting simulation...');
-    setIsLoading(true);
-    setIsRunning(false); // Stop the simulation on reset
-    setParams(newParams);
-    resetWithNewParams(newParams); // Explicitly tell the worker to reset
-    setSelectedActor(null);
-    setActorsInSelectedCell([]);
-    setIsControlsOpen(false); // Close panel on apply
-    useAnalyticsStore.getState().reset(); // Reset analytics data
-    useEventLogStore.getState().reset(); // Reset event log
+  const handleParamsChange = (newParams: SimulationParams, shouldReset = true) => {
+    setParams(newParams); // Always update main state
+
+    if (shouldReset) {
+        setLoadingMessage('Resetting simulation...');
+        setIsLoading(true);
+        setIsRunning(false);
+        resetWithNewParams(newParams);
+        setSelectedActor(null);
+        setActorsInSelectedCell([]);
+        setIsControlsOpen(false);
+        useAnalyticsStore.getState().reset();
+        useEventLogStore.getState().reset();
+    } else {
+        // Just update worker params live without resetting
+        updateLiveParams(newParams);
+    }
   };
 
   const handleActorSelection = useCallback((actor: CellContent | null) => {

--- a/src/components/Controls.test.tsx
+++ b/src/components/Controls.test.tsx
@@ -66,25 +66,25 @@ describe('Controls component', () => {
         const applyButton = screen.getByRole('button', { name: /Apply & Reset/i });
         fireEvent.click(applyButton);
         expect(mockOnParamsChange).toHaveBeenCalledTimes(1);
-        expect(mockOnParamsChange).toHaveBeenCalledWith(DEFAULT_SIM_PARAMS);
+        expect(mockOnParamsChange).toHaveBeenCalledWith(DEFAULT_SIM_PARAMS, true);
     });
 
     it('updates local state on input change and applies it on button click', () => {
         render(<Controls {...defaultProps} />);
         
         const gridWidthSlider = screen.getByLabelText(/Grid Width/i);
-        fireEvent.change(gridWidthSlider, { target: { value: '15' } });
+        fireEvent.change(gridWidthSlider, { target: { value: '20' } });
         
         const applyButton = screen.getByRole('button', { name: /Apply & Reset/i });
         fireEvent.click(applyButton);
         
         expect(mockOnParamsChange).toHaveBeenCalledTimes(1);
         expect(mockOnParamsChange).toHaveBeenCalledWith(expect.objectContaining({
-            gridWidth: 15
-        }));
+            gridWidth: 20
+        }), true);
     });
 
-    it('updates multiple local state values and applies them', () => {
+    it('updates multiple local state values and applies them', async () => {
         render(<Controls {...defaultProps} />);
     
         fireEvent.change(screen.getByLabelText(/Flowers/i), { target: { value: '50' } });
@@ -97,7 +97,7 @@ describe('Controls component', () => {
             initialFlowers: 50,
             initialInsects: 25,
             temperature: 30,
-        }));
+        }), true);
     });
     
     it('updates select input value and applies it', () => {
@@ -109,7 +109,7 @@ describe('Controls component', () => {
         
         expect(mockOnParamsChange).toHaveBeenCalledWith(expect.objectContaining({
             windDirection: 'NW'
-        }));
+        }), true);
     });
 
     it('updates hive grid area and applies it', async () => {
@@ -128,7 +128,7 @@ describe('Controls component', () => {
         
         expect(mockOnParamsChange).toHaveBeenCalledWith(expect.objectContaining({
             hiveGridArea: 15
-        }));
+        }), true);
     });
 
     it('updates honeybee parameters and applies them', async () => {
@@ -169,7 +169,7 @@ describe('Controls component', () => {
             hiveSpawnCost: 25,
             territoryMarkLifespan: 150,
             signalTTL: 15,
-        }));
+        }), true);
     });
     
     it('disables Save button when simulation is running', () => {

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -7,7 +7,7 @@ import { ACTOR_NAMES } from '../utils';
 
 interface ControlsProps {
     params: SimulationParams;
-    onParamsChange: (params: SimulationParams) => void;
+    onParamsChange: (params: SimulationParams, shouldReset: boolean) => void;
     isRunning: boolean;
     setIsRunning: (running: React.SetStateAction<boolean>) => void;
     onSave: () => void;
@@ -19,6 +19,8 @@ interface ControlsProps {
 
 const WIND_DIRECTIONS: WindDirection[] = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
 const FLOWER_DETAIL_OPTIONS = [4, 8, 16, 32, 64];
+const SIMULATION_SPEED_OPTIONS = [0.5, 1, 2, 4];
+const LIVE_UPDATABLE_PARAMS = ['simulationSpeed', 'notificationMode'];
 // Create a list of all spawnable actors for the UI
 const ACTOR_LIST = ['🐦', '🦅', ...Array.from(INSECT_DATA.keys())];
 
@@ -32,10 +34,11 @@ export const Controls: React.FC<ControlsProps> = ({ params, onParamsChange, isRu
 
     const handleParamChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
         const { name, value, type } = e.target;
-        const isFloat = ['humidity', 'herbicideFlowerDensityThreshold', 'humidityAmplitude', 'weatherEventChance', 'heavyRainHumidityIncrease', 'droughtHumidityDecrease', 'mutationChance', 'mutationAmount', 'beeWinterHoneyConsumption', 'hivePollenToHoneyRatio', 'beePollinationWanderChance', 'pheromoneStrengthDecay', 'spiderWebStaminaRegen', 'spiderWebTrapChance', 'spiderEscapeChanceModifier'].includes(name);
-        const isString = ['windDirection', 'notificationMode'].includes(name);
         
         setLocalParams(prev => {
+            const isFloat = ['humidity', 'herbicideFlowerDensityThreshold', 'humidityAmplitude', 'weatherEventChance', 'heavyRainHumidityIncrease', 'droughtHumidityDecrease', 'mutationChance', 'mutationAmount', 'beeWinterHoneyConsumption', 'hivePollenToHoneyRatio', 'beePollinationWanderChance', 'pheromoneStrengthDecay', 'spiderWebStaminaRegen', 'spiderWebTrapChance', 'spiderEscapeChanceModifier', 'simulationSpeed'].includes(name);
+            const isString = ['windDirection', 'notificationMode'].includes(name);
+        
             let processedValue: string | number | boolean = value;
             if (type === 'checkbox') {
                 processedValue = (e.target as HTMLInputElement).checked;
@@ -54,6 +57,10 @@ export const Controls: React.FC<ControlsProps> = ({ params, onParamsChange, isRu
                 if (newParams.initialFlowers > maxFlowers) {
                     newParams.initialFlowers = maxFlowers;
                 }
+            }
+
+            if (LIVE_UPDATABLE_PARAMS.includes(name)) {
+                onParamsChange(newParams, false);
             }
             
             return newParams;
@@ -78,7 +85,7 @@ export const Controls: React.FC<ControlsProps> = ({ params, onParamsChange, isRu
     };
 
     const handleApply = () => {
-        onParamsChange(localParams);
+        onParamsChange(localParams, true);
     };
     
     const maxFlowers = localParams.gridWidth * localParams.gridHeight;
@@ -356,6 +363,12 @@ export const Controls: React.FC<ControlsProps> = ({ params, onParamsChange, isRu
                 </CollapsibleSection>
 
                 <CollapsibleSection title="Graphics & UI" defaultOpen={false}>
+                    <label className="block" htmlFor="simulationSpeed">
+                        <span className="text-secondary text-sm">Simulation Speed</span>
+                        <select name="simulationSpeed" id="simulationSpeed" value={localParams.simulationSpeed} onChange={handleParamChange} className="w-full mt-1 p-2 bg-surface-hover border border-surface rounded-md text-white">
+                            {SIMULATION_SPEED_OPTIONS.map(val => <option key={val} value={val}>{val}x</option>)}
+                        </select>
+                    </label>
                     <label className="block" htmlFor="flowerDetailRadius">
                         <span className="text-secondary text-sm">Flower Detail</span>
                         <select name="flowerDetailRadius" id="flowerDetailRadius" value={localParams.flowerDetailRadius} onChange={handleParamChange} className="w-full mt-1 p-2 bg-surface-hover border border-surface rounded-md text-white">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import type { SimulationParams, InsectStats } from './types';
 
-export const TICK_RATE_MS = 250;
+export const BASE_TICK_RATE_MS = 250;
 
 export const DEFAULT_SIM_PARAMS: SimulationParams = {
     gridWidth: 15,
@@ -19,6 +19,7 @@ export const DEFAULT_SIM_PARAMS: SimulationParams = {
     herbicideCooldown: 90,
     herbicideSmokeExpansionCount: 2,
     notificationMode: 'both',
+    simulationSpeed: 1,
     // Seasonal Cycle Parameters
     seasonLengthInTicks: 150,
     temperatureAmplitude: 15, // Varies by ±15°C from base

--- a/src/hooks/useSimulation.ts
+++ b/src/hooks/useSimulation.ts
@@ -109,6 +109,10 @@ export const useSimulation = ({ setIsLoading }: UseSimulationProps) => {
         latestSummaryRef.current = null;
         setLatestSummary(null);
     }, []);
+    
+    const updateLiveParams = useCallback((params: SimulationParams) => {
+        workerRef.current?.postMessage({ type: 'set-live-params', payload: params });
+    }, []);
 
 
     const setIsRunning = (running: React.SetStateAction<boolean>) => {
@@ -123,5 +127,5 @@ export const useSimulation = ({ setIsLoading }: UseSimulationProps) => {
         }
     };
 
-    return { actors, isRunning, setIsRunning, workerRef, resetWithNewParams, isWorkerInitialized, latestSummaryRef, workerError, latestSummary };
+    return { actors, isRunning, setIsRunning, workerRef, resetWithNewParams, updateLiveParams, isWorkerInitialized, latestSummaryRef, workerError, latestSummary };
 };

--- a/src/lib/populationManager.ts
+++ b/src/lib/populationManager.ts
@@ -22,9 +22,11 @@ export class PopulationManager {
         this.params = params;
     }
 
-    public updateParams(params: SimulationParams) {
+    public updateParams(params: SimulationParams, reset = true) {
         this.params = params;
-        this.reset();
+        if (reset) {
+            this.reset();
+        }
     }
     
     public reset() {

--- a/src/lib/simulationEngine.ts
+++ b/src/lib/simulationEngine.ts
@@ -595,6 +595,10 @@ export class SimulationEngine {
             nextActorState.delete(seedId);
         }
         for (const flower of flowersToAdd) {
+            flower.age += (nextActorState.get(flower.id) as FlowerSeed)?.age || 0;
+            if (flower.age >= flower.maturationPeriod) {
+                flower.isMature = true;
+            }
             nextActorState.set(flower.id, flower);
             newFlowerCount++;
             events.push({ message: '🌱 A new flower has bloomed!', type: 'success', importance: 'low' });
@@ -729,19 +733,21 @@ export class SimulationEngine {
         await Promise.all(regenerationPromises);
     }
 
-    public setParams(newParams: SimulationParams) {
+    public setParams(newParams: SimulationParams, reset = true) {
         this.params = newParams;
-        this.tick = 0;
-        this.totalInsectsEaten = 0;
-        this.populationManager.updateParams(newParams);
-        this.asyncFlowerFactory.reset();
+        this.populationManager.updateParams(newParams, reset);
         this.asyncFlowerFactory.updateParams(this.params);
-        this.environmentState = {
-            currentTemperature: newParams.temperature,
-            currentHumidity: newParams.humidity,
-            season: 'Summer',
-            currentWeatherEvent: { type: 'none', duration: 0 },
-        };
-        this.loadChampionsFromDb();
+        if (reset) {
+            this.tick = 0;
+            this.totalInsectsEaten = 0;
+            this.asyncFlowerFactory.reset();
+            this.environmentState = {
+                currentTemperature: newParams.temperature,
+                currentHumidity: newParams.humidity,
+                season: 'Summer',
+                currentWeatherEvent: { type: 'none', duration: 0 },
+            };
+            this.loadChampionsFromDb();
+        }
     }
 }

--- a/src/simulation.worker.ts
+++ b/src/simulation.worker.ts
@@ -2,7 +2,7 @@
 
 import { SimulationEngine } from './lib/simulationEngine';
 import { flowerService } from './services/flowerService';
-import { TICK_RATE_MS } from './constants';
+import { BASE_TICK_RATE_MS } from './constants';
 import type { SimulationParams, Flower } from './types';
 import { createNewFlower, createInitialMobileActors, initializeHivesAndBees, initializeAntColonies, initializeSpiders } from './lib/simulationInitializer';
 
@@ -34,8 +34,11 @@ const gameLoop = async () => {
     const { events, summary, deltas } = await engine.calculateNextTick();
 
     self.postMessage({ type: 'tick-update', payload: { deltas, events, summary } });
+    
+    const currentParams = engine.getGridState().params;
+    const tickRate = BASE_TICK_RATE_MS / (currentParams.simulationSpeed || 1);
 
-    gameLoopTimeoutId = self.setTimeout(gameLoop, TICK_RATE_MS);
+    gameLoopTimeoutId = self.setTimeout(gameLoop, tickRate);
 };
 
 self.onmessage = async (e: MessageEvent) => {
@@ -124,6 +127,13 @@ self.onmessage = async (e: MessageEvent) => {
 
             engine.initializeGridWithActors(allActors);
             self.postMessage({ type: 'init-complete', payload: engine.getGridState() });
+            break;
+        }
+        
+        case 'set-live-params': {
+            if (engine) {
+                engine.setParams(payload, false);
+            }
             break;
         }
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -35,6 +35,7 @@ export interface SimulationParams {
     herbicideCooldown: number;
     herbicideSmokeExpansionCount: number;
     notificationMode: NotificationMode;
+    simulationSpeed: number;
     // Seasonal Cycle Parameters
     seasonLengthInTicks: number;
     temperatureAmplitude: number;


### PR DESCRIPTION
This commit introduces two major features to enhance user interactivity: the ability to change the simulation speed and a new mechanism to update certain parameters live without resetting the simulation.

-   **Simulation Speed Control:**
    -   A "Simulation Speed" dropdown (0.5x, 1x, 2x, 4x) has been added to the UI under the "Graphics & UI" section.
    -   The simulation worker now adjusts the tick rate based on this setting, allowing users to fast-forward or slow down the simulation dynamically.

-   **Live Parameter Updates:**
    -   A new system has been implemented to allow specific simulation parameters to be changed in real-time without a full reset.
    -   Initially, `simulationSpeed` and `notificationMode` can be updated live.
    -   This is achieved by sending a `set-live-params` message to the worker, which updates the simulation engine's state without resetting the tick count or actor states.
    -   The `onParamsChange` handler in the main app now accepts a `shouldReset` flag to differentiate between live updates and changes that require a full reset.

-   **Bug Fix:**
    -   Fixed an issue where the age of a `FlowerSeed` was not transferred to the `Flower` upon blooming. The time spent as a seed now correctly counts towards the flower's maturation period.

-   **Refactoring & Tests:**
    -   The `useSimulation` hook now exposes an `updateLiveParams` function.
    -   `SimulationEngine` and `PopulationManager` methods for updating parameters were refactored to support non-resetting updates.
    -   Unit tests for the `Controls` component have been updated to accommodate the new function signature for parameter changes.

-   **Version Bump:**
    -   The package version has been incremented to `2.22.0` to reflect these new features.