### PR TITLE
fix(pop-count): Include stored insects in total counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evogarden",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "description": "A dynamic garden simulation where flowers evolve under the pressure of insects and birds. Watch a Darwinian battlefield unfold as flowers, insects, and birds interact in a delicate ecosystem, with visual traits driven by NEAT Algorithm.",
   "private": true,
   "type": "module",

--- a/src/lib/simulationEngine.ts
+++ b/src/lib/simulationEngine.ts
@@ -305,6 +305,7 @@ export class SimulationEngine {
         let healingFlowerCount = 0, toxicFlowerCount = 0;
         let caterpillarCount = 0, butterflyCount = 0, beetleCount = 0, ladybugCount = 0, snailCount = 0, beeCount = 0, scorpionCount = 0, antCount = 0, spiderCount = 0;
         let hiveCount = 0, totalHoney = 0, colonyCount = 0, totalAntFood = 0;
+        let storedBeesCount = 0, storedAntsCount = 0;
 
 
         for (const actor of nextActorState.values()) {
@@ -367,22 +368,27 @@ export class SimulationEngine {
             } else if (actor.type === 'hive') {
                 hiveCount++;
                 totalHoney += (actor as Hive).honey;
+                storedBeesCount += (actor as Hive).storedBees || 0;
             } else if (actor.type === 'antColony') {
                 colonyCount++;
                 totalAntFood += (actor as AntColony).foodReserves;
+                storedAntsCount += (actor as AntColony).storedAnts || 0;
             }
         }
 
         const flowerDensity = (flowerCountForStats + seedCount) / (this.params.gridWidth * this.params.gridHeight);
-        const totalInsectCount = insectCount + cockroachCount;
+        const totalInsectCount = insectCount + cockroachCount + storedBeesCount + storedAntsCount;
 
         return {
             tick: this.tick,
             flowerCount: flowerCountForStats + seedCount,
             insectCount: totalInsectCount,
             birdCount, eagleCount, eggCount, herbicidePlaneCount, herbicideSmokeCount, corpseCount, cockroachCount, cocoonCount,
-            caterpillarCount, butterflyCount, beetleCount, ladybugCount, snailCount, beeCount, scorpionCount,
-            antCount, spiderCount,
+            caterpillarCount, butterflyCount, beetleCount, ladybugCount, snailCount, 
+            beeCount: beeCount + storedBeesCount, 
+            scorpionCount,
+            antCount: antCount + storedAntsCount, 
+            spiderCount,
             hiveCount,
             colonyCount,
             totalHoney,


### PR DESCRIPTION
The simulation statistics for total insects, bees, and ants were inaccurate as they only counted active entities on the grid. This did not account for bees stored within Hives or ants stored within Ant Colonies, leading to an under-reporting of the total population.

This patch updates the statistics calculation to sum the `storedBees` from Hives and `storedAnts` from Ant Colonies. These values are now included in the total `insectCount`, `beeCount`, and `antCount`, providing a more accurate representation of the ecosystem's population.