### PR TITLE
fix(ant-colony-spring-boost): Boost ant colonies at the start of spring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evogarden",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "description": "A dynamic garden simulation where flowers evolve under the pressure of insects and birds. Watch a Darwinian battlefield unfold as flowers, insects, and birds interact in a delicate ecosystem, with visual traits driven by NEAT Algorithm.",
   "private": true,
   "type": "module",

--- a/src/lib/simulationEngine.ts
+++ b/src/lib/simulationEngine.ts
@@ -540,6 +540,19 @@ export class SimulationEngine {
                     }
                 }
 
+                // Boost ant colonies at the start of spring
+                const colonies = Array.from(nextActorState.values()).filter(a => a.type === 'antColony') as AntColony[];
+                if (colonies.length > 0) {
+                    let boosted = false;
+                    for (const colony of colonies) {
+                        colony.foodReserves = this.params.antColonySpawnThreshold + (2 * this.params.antColonySpawnCost);
+                        boosted = true;
+                    }
+                    if (boosted) {
+                         events.push({ message: '⛰️ Spring has revitalized the ant colonies!', type: 'success', importance: 'high' });
+                    }
+                }
+
                 events.push({ message: '🌱 Spring has arrived, and new life stirs in the garden!', type: 'success', importance: 'high' });                          
                 const tempGridForPlacement = this.grid.map(row => row.map(cell => [...cell]));
                 


### PR DESCRIPTION
This patch addresses an issue where ant colonies would often deplete their food reserves over the winter and die out immediately at the start of spring before they could forage.

To ensure colony survival and promote a more balanced ecosystem, this change provides a food boost to all existing ant colonies when spring begins. Their food reserves are now set to a level sufficient to meet the spawn threshold and cover the cost of two spawn cycles, giving them a strong start for the new season.

A high-importance event message has also been added to notify when the colonies are revitalized.